### PR TITLE
fix: upgrade test harness from protocol v5 to v6

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -9,7 +9,7 @@ linters:
   enable:
     - durationcheck
     - errcheck
-    - exportloopref
+    - copyloopvar
     - forcetypeassert
     - godot
     - gofmt
@@ -20,8 +20,8 @@ linters:
     - nilerr
     - predeclared
     - staticcheck
-    - tenv
+    - usetesting
     - unconvert
     - unparam
     - unused
-    - vet
+    - govet

--- a/internal/acctest/acctest.go
+++ b/internal/acctest/acctest.go
@@ -4,16 +4,16 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-framework/providerserver"
-	"github.com/hashicorp/terraform-plugin-go/tfprotov5"
+	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
 	"github.com/vpsie/terraform-provider-vpsie/internal/provider"
 )
 
-// TestAccProtoV5ProviderFactories are used to instantiate a provider during
+// TestAccProtoV6ProviderFactories are used to instantiate a provider during
 // acceptance testing. The factory function will be invoked for every Terraform
 // CLI command executed to create a provider server to which the CLI can
 // reattach.
-var TestAccProtoV5ProviderFactories = map[string]func() (tfprotov5.ProviderServer, error){
-	"vpsie": providerserver.NewProtocol5WithError(provider.New("test")()),
+var TestAccProtoV6ProviderFactories = map[string]func() (tfprotov6.ProviderServer, error){
+	"vpsie": providerserver.NewProtocol6WithError(provider.New("test")()),
 }
 
 func TestAccPreCheck(t *testing.T) {

--- a/internal/services/accesstoken/accesstoken_datasource.go
+++ b/internal/services/accesstoken/accesstoken_datasource.go
@@ -15,7 +15,7 @@ type accessTokenDataSource struct {
 }
 
 type accessTokenDataSourceModel struct {
-	ID     types.String         `tfsdk:"id"`
+	ID     types.String       `tfsdk:"id"`
 	Tokens []accessTokenModel `tfsdk:"tokens"`
 }
 

--- a/internal/services/bucket/bucket_datasource.go
+++ b/internal/services/bucket/bucket_datasource.go
@@ -15,7 +15,7 @@ type bucketDataSource struct {
 }
 
 type bucketDataSourceModel struct {
-	ID      types.String   `tfsdk:"id"`
+	ID      types.String  `tfsdk:"id"`
 	Buckets []bucketModel `tfsdk:"buckets"`
 }
 

--- a/internal/services/bucket/bucket_resource.go
+++ b/internal/services/bucket/bucket_resource.go
@@ -24,17 +24,17 @@ type bucketResource struct {
 }
 
 type bucketResourceModel struct {
-	Identifier  types.String `tfsdk:"identifier"`
-	BucketName  types.String `tfsdk:"bucket_name"`
-	ProjectID   types.String `tfsdk:"project_id"`
+	Identifier   types.String `tfsdk:"identifier"`
+	BucketName   types.String `tfsdk:"bucket_name"`
+	ProjectID    types.String `tfsdk:"project_id"`
 	DataCenterID types.String `tfsdk:"datacenter_id"`
-	FileListing types.Bool   `tfsdk:"file_listing"`
-	AccessKey   types.String `tfsdk:"access_key"`
-	SecretKey   types.String `tfsdk:"secret_key"`
-	EndPoint    types.String `tfsdk:"endpoint"`
-	State       types.String `tfsdk:"state"`
-	CreatedBy   types.String `tfsdk:"created_by"`
-	CreatedOn   types.String `tfsdk:"created_on"`
+	FileListing  types.Bool   `tfsdk:"file_listing"`
+	AccessKey    types.String `tfsdk:"access_key"`
+	SecretKey    types.String `tfsdk:"secret_key"`
+	EndPoint     types.String `tfsdk:"endpoint"`
+	State        types.String `tfsdk:"state"`
+	CreatedBy    types.String `tfsdk:"created_by"`
+	CreatedOn    types.String `tfsdk:"created_on"`
 }
 
 func NewBucketResource() resource.Resource {

--- a/internal/services/gateway/gateway_data_source.go
+++ b/internal/services/gateway/gateway_data_source.go
@@ -155,7 +155,7 @@ func (g *gatewayDataSource) Read(ctx context.Context, req datasource.ReadRequest
 
 	for _, gateway := range gateways {
 		attached := []AttachedVM{}
-		if gateway.AttachedVms != nil && len(gateway.AttachedVms) > 0 {
+		if len(gateway.AttachedVms) > 0 {
 			for _, vm := range gateway.AttachedVms {
 				attached = append(attached, AttachedVM{
 					Identifier:       types.StringValue(vm.Identifier),

--- a/internal/services/gateway/gateway_resource.go
+++ b/internal/services/gateway/gateway_resource.go
@@ -255,7 +255,7 @@ func (g *gatewayResource) Read(ctx context.Context, req resource.ReadRequest, re
 
 	// Overwrite items with refreshed state
 	attached := []AttachedVM{}
-	if gateway.AttachedVms != nil && len(gateway.AttachedVms) > 0 {
+	if len(gateway.AttachedVms) > 0 {
 		for _, vm := range gateway.AttachedVms {
 			attached = append(attached, AttachedVM{
 				Identifier:       types.StringValue(vm.Identifier),
@@ -346,7 +346,7 @@ func (g *gatewayResource) Update(ctx context.Context, req resource.UpdateRequest
 	}
 
 	attached := []AttachedVM{}
-	if gateway.AttachedVms != nil && len(gateway.AttachedVms) > 0 {
+	if len(gateway.AttachedVms) > 0 {
 		for _, vm := range gateway.AttachedVms {
 			attached = append(attached, AttachedVM{
 				Identifier:       types.StringValue(vm.Identifier),

--- a/internal/services/monitoring/monitoring_rule_datasource.go
+++ b/internal/services/monitoring/monitoring_rule_datasource.go
@@ -52,10 +52,10 @@ func (d *monitoringRuleDataSource) Schema(_ context.Context, _ datasource.Schema
 				Computed: true,
 				NestedObject: schema.NestedAttributeObject{
 					Attributes: map[string]schema.Attribute{
-						"identifier": schema.StringAttribute{Computed: true},
-						"rule_name":  schema.StringAttribute{Computed: true},
-						"metric_type": schema.StringAttribute{Computed: true},
-						"condition":   schema.StringAttribute{Computed: true},
+						"identifier":     schema.StringAttribute{Computed: true},
+						"rule_name":      schema.StringAttribute{Computed: true},
+						"metric_type":    schema.StringAttribute{Computed: true},
+						"condition":      schema.StringAttribute{Computed: true},
 						"threshold_type": schema.StringAttribute{Computed: true},
 						"threshold":      schema.Int64Attribute{Computed: true},
 						"period":         schema.Int64Attribute{Computed: true},

--- a/internal/services/snapshot/snapshot_policy_datasource.go
+++ b/internal/services/snapshot/snapshot_policy_datasource.go
@@ -15,7 +15,7 @@ type snapshotPolicyDataSource struct {
 }
 
 type snapshotPolicyDataSourceModel struct {
-	ID       types.String                `tfsdk:"id"`
+	ID       types.String              `tfsdk:"id"`
 	Policies []snapshotPolicyListModel `tfsdk:"policies"`
 }
 

--- a/internal/services/storage/storage_resource_test.go
+++ b/internal/services/storage/storage_resource_test.go
@@ -10,7 +10,7 @@ import (
 
 func TestAccStorageResource(t *testing.T) {
 	resource.Test(t, resource.TestCase{
-		ProtoV5ProviderFactories: acctest.TestAccProtoV5ProviderFactories,
+		ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			// create and read testing
 			{
@@ -48,7 +48,7 @@ func TestAccStorageResource_Resize(t *testing.T) {
 	var storageName = "test-update"
 
 	resource.ParallelTest(t, resource.TestCase{
-		ProtoV5ProviderFactories: acctest.TestAccProtoV5ProviderFactories,
+		ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			// create and read testing
 			{


### PR DESCRIPTION
## Summary

- Switches test infrastructure from Terraform Plugin Protocol V5 to V6 to fix protocol version 5 cannot have Attributes set error
- The provider schemas use ListNestedAttribute with nested Attributes, which requires Protocol V6
- Production server already uses Protocol V6 via providerserver.Serve(); this aligns the test harness to match

## Test plan

- [ ] Verify go build passes
- [ ] Verify go vet passes on changed packages
- [ ] Run acceptance tests and confirm the protocol version error no longer occurs

Generated with Claude Code (https://claude.com/claude-code)