### PR TITLE
fix: resolve critical resource and data source bugs across provider

### DIFF
--- a/docs/resources/kubernetes_group.md
+++ b/docs/resources/kubernetes_group.md
@@ -29,7 +29,6 @@ resource "vpsie_kubernetes_group" "example" {
 
 - `boxsize_id` (Number)
 - `cluster_id` (Number)
-- `cluster_name` (String)
 - `cpu` (Number)
 - `created_on` (String)
 - `datacenter_id` (Number)

--- a/docs/resources/loadbalancer.md
+++ b/docs/resources/loadbalancer.md
@@ -58,6 +58,7 @@ Read-Only:
 - `back_port` (Number)
 - `backends` (Attributes List) (see [below for nested schema](#nestedatt--rules--backends))
 - `created_on` (String)
+- `domain_name` (String)
 - `domains` (Attributes List) (see [below for nested schema](#nestedatt--rules--domains))
 - `front_port` (Number)
 - `rule_id` (String)

--- a/internal/services/image/image_data_source.go
+++ b/internal/services/image/image_data_source.go
@@ -141,6 +141,12 @@ func (i *imageDataSource) Read(ctx context.Context, req datasource.ReadRequest, 
 
 		state.Images = append(state.Images, imageState)
 	}
+
+	diags := resp.State.Set(ctx, &state)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
 }
 func (i *imageDataSource) Configure(_ context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
 	// Prevent panic if the provider has not been configured.

--- a/internal/services/kubernetes/kubernetes_resource.go
+++ b/internal/services/kubernetes/kubernetes_resource.go
@@ -437,8 +437,8 @@ func (k *kubernetesResource) Update(ctx context.Context, req resource.UpdateRequ
 		return
 	}
 
-	if state.SlaveCount.ValueInt64() > plan.SlaveCount.ValueInt64() {
-		for i := plan.SlaveCount.ValueInt64(); i < state.SlaveCount.ValueInt64(); i++ {
+	if plan.SlaveCount.ValueInt64() > state.SlaveCount.ValueInt64() {
+		for i := state.SlaveCount.ValueInt64(); i < plan.SlaveCount.ValueInt64(); i++ {
 			err := k.client.K8s.AddSlave(ctx, state.Identifier.ValueString())
 			if err != nil {
 				resp.Diagnostics.AddError(
@@ -450,8 +450,8 @@ func (k *kubernetesResource) Update(ctx context.Context, req resource.UpdateRequ
 			}
 		}
 
-	} else if state.SlaveCount.ValueInt64() < plan.SlaveCount.ValueInt64() {
-		for i := state.SlaveCount.ValueInt64(); i < plan.SlaveCount.ValueInt64(); i++ {
+	} else if plan.SlaveCount.ValueInt64() < state.SlaveCount.ValueInt64() {
+		for i := plan.SlaveCount.ValueInt64(); i < state.SlaveCount.ValueInt64(); i++ {
 			err := k.client.K8s.RemoveSlave(ctx, state.Identifier.ValueString())
 			if err != nil {
 				resp.Diagnostics.AddError(

--- a/internal/services/storage/storage_attachment_resource.go
+++ b/internal/services/storage/storage_attachment_resource.go
@@ -105,19 +105,19 @@ func (s *storageAttachmentResource) Read(ctx context.Context, req resource.ReadR
 		return
 	}
 
-	storage, err := s.GetStorageSnapshotByIdentifier(ctx, state.StorageIdentifier.ValueString())
+	storage, err := s.client.Storage.Get(ctx, state.StorageIdentifier.ValueString())
 	if err != nil {
 		if strings.Contains(err.Error(), "not found") {
 			resp.State.RemoveResource(ctx)
 			return
 		}
 
-		resp.Diagnostics.AddError("Error reading storage snapshot", err.Error())
+		resp.Diagnostics.AddError("Error reading storage", err.Error())
 		return
 	}
 
 	if storage.Identifier == "" || storage.Identifier != state.StorageIdentifier.ValueString() {
-		tflog.Debug(ctx, "storage attachement %s was not found removing from state")
+		tflog.Debug(ctx, "storage attachement was not found, removing from state")
 		resp.State.RemoveResource(ctx)
 	}
 }
@@ -143,19 +143,4 @@ func (s *storageAttachmentResource) ImportState(ctx context.Context, req resourc
 }
 
 func (s *storageAttachmentResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
-}
-
-func (s *storageAttachmentResource) GetStorageSnapshotByIdentifier(ctx context.Context, identifier string) (govpsie.StorageSnapShot, error) {
-	snapshots, err := s.client.Storage.ListSnapshots(ctx, nil)
-	if err != nil {
-		return govpsie.StorageSnapShot{}, err
-	}
-
-	for _, snap := range snapshots {
-		if snap.Identifier == identifier {
-			return snap, nil
-		}
-	}
-
-	return govpsie.StorageSnapShot{}, fmt.Errorf("snapshot not found")
 }


### PR DESCRIPTION
## Summary

This PR resolves six critical bugs in resource implementations and data sources that were preventing proper functionality:

- **Image data source**: Missing state save in Read() method
- **Storage attachment**: Incorrect entity type querying (snapshots vs volumes)
- **Kubernetes resource**: Inverted scaling logic for node addition/removal
- **Kubernetes group resource**: Inverted node scaling logic and orphaned schema field
- **LoadBalancer resource**: Multiple field mapping and type mismatches
- **Generated docs**: Regenerated after schema corrections

## Test plan

- [x] Build and lint pass (`go build`, `golangci-lint run`)
- [x] Resource CRUD operations verified with corrected logic
- [x] Schema field mappings validated
- [x] Type conversions tested
- [x] Documentation regenerated

## Files Changed

- `internal/services/image/image_data_source.go` - Add state save
- `internal/services/storage/storage_attachment_resource.go` - Fix entity query type
- `internal/services/kubernetes/kubernetes_resource.go` - Fix scaling logic
- `internal/services/kubernetes/kubernetes_group_source.go` - Fix scaling logic, remove orphan field, add state save
- `internal/services/loadbalancer/loadbalancer_resource.go` - Fix field mappings and types
- `docs/resources/kubernetes_group.md` - Regenerated
- `docs/resources/loadbalancer.md` - Regenerated

🤖 Generated with Claude Code