### PR TITLE
Fix data source state persistence, tfsdk tags, and omitempty

### DIFF
--- a/docs/data-sources/kubernetes.md
+++ b/docs/data-sources/kubernetes.md
@@ -30,6 +30,7 @@ data "vpsie_kubernetes" "example" {}
 Read-Only:
 
 - `cluster_name` (String)
+- `color` (String)
 - `cpu` (Number)
 - `created_by` (String)
 - `created_on` (String)

--- a/internal/services/backup/backup_data_source.go
+++ b/internal/services/backup/backup_data_source.go
@@ -141,6 +141,13 @@ func (b *backupDataSource) Read(ctx context.Context, req datasource.ReadRequest,
 
 		state.Backups = append(state.Backups, backupState)
 	}
+
+	state.ID = types.StringValue("backups")
+	diags := resp.State.Set(ctx, &state)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
 }
 func (b *backupDataSource) Configure(_ context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
 	// Prevent panic if the provider has not been configured.

--- a/internal/services/domain/domain_data_source.go
+++ b/internal/services/domain/domain_data_source.go
@@ -96,6 +96,13 @@ func (d *domainDataSource) Read(ctx context.Context, req datasource.ReadRequest,
 
 		state.Domains = append(state.Domains, domainState)
 	}
+
+	state.ID = types.StringValue("domains")
+	diags := resp.State.Set(ctx, &state)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
 }
 func (d *domainDataSource) Configure(_ context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
 	// Prevent panic if the provider has not been configured.

--- a/internal/services/firewall/firewall_data_source.go
+++ b/internal/services/firewall/firewall_data_source.go
@@ -37,8 +37,8 @@ type firewallsModel struct {
 }
 
 type FirewallRules struct {
-	InBound  []InBoundFirewallRules  `tfsdk:"inBound"`
-	OutBound []OutBoundFirewallRules `tfsdk:"outBound"`
+	InBound  []InBoundFirewallRules  `tfsdk:"in_bound"`
+	OutBound []OutBoundFirewallRules `tfsdk:"out_bound"`
 }
 
 type InBoundFirewallRules struct {
@@ -51,12 +51,12 @@ type InBoundFirewallRules struct {
 	Dest       types.List   `tfsdk:"dest"`
 	Dport      types.String `tfsdk:"dport"`
 	Proto      types.String `tfsdk:"proto"`
-	Source     types.List   `tfsdk:"source,omitempty"`
+	Source     types.List   `tfsdk:"source"`
 	Sport      types.String `tfsdk:"sport"`
 	Enable     types.Int64  `tfsdk:"enable"`
-	Iface      types.String `tfsdk:"iface,omitempty"`
-	Log        types.String `tfsdk:"log,omitempty"`
-	Macro      types.String `tfsdk:"macro,omitempty"`
+	Iface      types.String `tfsdk:"iface"`
+	Log        types.String `tfsdk:"log"`
+	Macro      types.String `tfsdk:"macro"`
 	Identifier types.String `tfsdk:"identifier"`
 	CreatedOn  types.String `tfsdk:"created_on"`
 	UpdatedOn  types.String `tfsdk:"updated_on"`
@@ -69,15 +69,15 @@ type OutBoundFirewallRules struct {
 	Action     types.String `tfsdk:"action"`
 	Type       types.String `tfsdk:"type"`
 	Comment    types.String `tfsdk:"comment"`
-	Dest       types.List   `tfsdk:"dest,omitempty"`
+	Dest       types.List   `tfsdk:"dest"`
 	Dport      types.String `tfsdk:"dport"`
 	Proto      types.String `tfsdk:"proto"`
 	Source     types.List   `tfsdk:"source"`
 	Sport      types.String `tfsdk:"sport"`
 	Enable     types.Int64  `tfsdk:"enable"`
-	Iface      types.String `tfsdk:"iface,omitempty"`
-	Log        types.String `tfsdk:"log,omitempty"`
-	Macro      types.String `tfsdk:"macro,omitempty"`
+	Iface      types.String `tfsdk:"iface"`
+	Log        types.String `tfsdk:"log"`
+	Macro      types.String `tfsdk:"macro"`
 	Identifier types.String `tfsdk:"identifier"`
 	CreatedOn  types.String `tfsdk:"created_on"`
 	UpdatedOn  types.String `tfsdk:"updated_on"`
@@ -412,6 +412,13 @@ func (f *firewallDataSource) Read(ctx context.Context, req datasource.ReadReques
 		}
 
 		state.Firewalls = append(state.Firewalls, firewallState)
+	}
+
+	state.ID = types.StringValue("firewalls")
+	diags := resp.State.Set(ctx, &state)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
 	}
 }
 func (g *firewallDataSource) Configure(_ context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {

--- a/internal/services/gateway/gateway_data_source.go
+++ b/internal/services/gateway/gateway_data_source.go
@@ -27,9 +27,9 @@ type gatewaysModel struct {
 	IP                   types.String `tfsdk:"ip"`
 	IsReserved           types.Int64  `tfsdk:"is_reserved"`
 	IPVersion            types.String `tfsdk:"ip_version"`
-	BoxID                types.Int64  `tfsdk:"box_id,omitempty"`
+	BoxID                types.Int64  `tfsdk:"box_id"`
 	IsPrimary            types.Int64  `tfsdk:"is_primary"`
-	Notes                types.String `tfsdk:"notes,omitempty"`
+	Notes                types.String `tfsdk:"notes"`
 	UserID               types.Int64  `tfsdk:"user_id"`
 	UpdatedAt            types.String `tfsdk:"updated_at"`
 	IsGatewayReserved    types.Int64  `tfsdk:"is_gateway_reserved"`
@@ -185,6 +185,13 @@ func (g *gatewayDataSource) Read(ctx context.Context, req datasource.ReadRequest
 		}
 
 		state.Gateways = append(state.Gateways, gatewayState)
+	}
+
+	state.ID = types.StringValue("gateways")
+	diags := resp.State.Set(ctx, &state)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
 	}
 }
 func (g *gatewayDataSource) Configure(_ context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {

--- a/internal/services/gateway/gateway_resource.go
+++ b/internal/services/gateway/gateway_resource.go
@@ -32,9 +32,9 @@ type gatewayResourceModel struct {
 	IP                   types.String `tfsdk:"ip"`
 	IsReserved           types.Int64  `tfsdk:"is_reserved"`
 	IPVersion            types.String `tfsdk:"ip_version"`
-	BoxID                types.Int64  `tfsdk:"box_id,omitempty"`
+	BoxID                types.Int64  `tfsdk:"box_id"`
 	IsPrimary            types.Int64  `tfsdk:"is_primary"`
-	Notes                types.String `tfsdk:"notes,omitempty"`
+	Notes                types.String `tfsdk:"notes"`
 	UserID               types.Int64  `tfsdk:"user_id"`
 	UpdatedAt            types.String `tfsdk:"updated_at"`
 	IsGatewayReserved    types.Int64  `tfsdk:"is_gateway_reserved"`

--- a/internal/services/image/image_data_source.go
+++ b/internal/services/image/image_data_source.go
@@ -142,6 +142,7 @@ func (i *imageDataSource) Read(ctx context.Context, req datasource.ReadRequest, 
 		state.Images = append(state.Images, imageState)
 	}
 
+	state.ID = types.StringValue("images")
 	diags := resp.State.Set(ctx, &state)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {

--- a/internal/services/kubernetes/kubernetes_data_source.go
+++ b/internal/services/kubernetes/kubernetes_data_source.go
@@ -23,7 +23,7 @@ type kubernetesDataSourceModel struct {
 type kubernetesModel struct {
 	ClusterName  types.String  `tfsdk:"cluster_name"`
 	Identifier   types.String  `tfsdk:"identifier"`
-	MasterCount  types.Int64   `tfsdk:"count"`
+	MasterCount  types.Int64   `tfsdk:"master_count"`
 	CreatedOn    types.String  `tfsdk:"created_on"`
 	UpdatedOn    types.String  `tfsdk:"updated_on"`
 	CreatedBy    types.String  `tfsdk:"created_by"`
@@ -88,6 +88,9 @@ func (i *kubernetesDataSource) Schema(_ context.Context, _ datasource.SchemaRequ
 						"traffic": schema.Int64Attribute{
 							Computed: true,
 						},
+						"color": schema.StringAttribute{
+							Computed: true,
+						},
 						"price": schema.Float64Attribute{
 							Computed: true,
 						},
@@ -137,6 +140,13 @@ func (k *kubernetesDataSource) Read(ctx context.Context, req datasource.ReadRequ
 		}
 
 		state.Kubernetes = append(state.Kubernetes, k8sState)
+	}
+
+	state.ID = types.StringValue("kubernetes")
+	diags := resp.State.Set(ctx, &state)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
 	}
 }
 func (k *kubernetesDataSource) Configure(_ context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {

--- a/internal/services/kubernetes/kubernetes_group_data_source.go
+++ b/internal/services/kubernetes/kubernetes_group_data_source.go
@@ -152,6 +152,8 @@ func (k *kubernetesGroupDataSource) Read(ctx context.Context, req datasource.Rea
 				"Error Getting Kubernetes Groups",
 				"Could not get Kubernetes Groups, unexpected error: "+err.Error(),
 			)
+
+			return
 		}
 
 		for _, k8Group := range k8sGroups {
@@ -179,6 +181,13 @@ func (k *kubernetesGroupDataSource) Read(ctx context.Context, req datasource.Rea
 			})
 		}
 
+	}
+
+	state.ID = types.StringValue("kubernetes_groups")
+	diags := resp.State.Set(ctx, &state)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
 	}
 }
 

--- a/internal/services/loadbalancer/loadbalancer_data_source.go
+++ b/internal/services/loadbalancer/loadbalancer_data_source.go
@@ -141,6 +141,13 @@ func (k *loadbalancerDataSource) Read(ctx context.Context, req datasource.ReadRe
 
 		state.Loadbalancers = append(state.Loadbalancers, lbState)
 	}
+
+	state.ID = types.StringValue("loadbalancers")
+	diags := resp.State.Set(ctx, &state)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
 }
 func (l *loadbalancerDataSource) Configure(_ context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
 	// Prevent panic if the provider has not been configured.

--- a/internal/services/project/project_data_source.go
+++ b/internal/services/project/project_data_source.go
@@ -111,6 +111,13 @@ func (p *projectDataSource) Read(ctx context.Context, req datasource.ReadRequest
 
 		state.Projects = append(state.Projects, projectState)
 	}
+
+	state.ID = types.StringValue("projects")
+	diags := resp.State.Set(ctx, &state)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
 }
 func (p *projectDataSource) Configure(_ context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
 	// Prevent panic if the provider has not been configured.


### PR DESCRIPTION
## Summary
- Add missing resp.State.Set() and state.ID to 8 data sources: backup, domain, firewall, gateway, kubernetes, kubernetes_group, loadbalancer, project
- Add missing state.ID to image data source
- Fix firewall tfsdk tags: inBound->in_bound, outBound->out_bound
- Fix kubernetes data source: tfsdk count->master_count, add color to schema
- Remove invalid omitempty from 12 tfsdk tags
- Add missing return after error in kubernetes_group_data_source
- Regenerate docs