### PR TITLE
fix: correct resource configuration error messages and remove unused function

### DIFF
--- a/internal/services/backup/backup_resource.go
+++ b/internal/services/backup/backup_resource.go
@@ -135,7 +135,7 @@ func (b *backupResource) Configure(_ context.Context, req resource.ConfigureRequ
 	client, ok := req.ProviderData.(*govpsie.Client)
 	if !ok {
 		resp.Diagnostics.AddError(
-			"Unexpected Data Source Configuration Type",
+			"Unexpected Resource Configuration Type",
 			fmt.Sprintf("Expected *govpsie.Client, got %T. Please report  this issue to the provider developers.", req.ProviderData),
 		)
 

--- a/internal/services/domain/domain_resource.go
+++ b/internal/services/domain/domain_resource.go
@@ -93,7 +93,7 @@ func (d *domainResource) Configure(_ context.Context, req resource.ConfigureRequ
 	client, ok := req.ProviderData.(*govpsie.Client)
 	if !ok {
 		resp.Diagnostics.AddError(
-			"Unexpected Data Source Configuration Type",
+			"Unexpected Resource Configuration Type",
 			fmt.Sprintf("Expected *govpsie.Client, got %T. Please report  this issue to the provider developers.", req.ProviderData),
 		)
 

--- a/internal/services/firewall/firewall_resource.go
+++ b/internal/services/firewall/firewall_resource.go
@@ -291,7 +291,7 @@ func (g *firewallResource) Configure(_ context.Context, req resource.ConfigureRe
 	client, ok := req.ProviderData.(*govpsie.Client)
 	if !ok {
 		resp.Diagnostics.AddError(
-			"Unexpected Data Source Configuration Type",
+			"Unexpected Resource Configuration Type",
 			fmt.Sprintf("Expected *govpsie.Client, got %T. Please report  this issue to the provider developers.", req.ProviderData),
 		)
 

--- a/internal/services/gateway/gateway_resource.go
+++ b/internal/services/gateway/gateway_resource.go
@@ -184,7 +184,7 @@ func (g *gatewayResource) Configure(_ context.Context, req resource.ConfigureReq
 	client, ok := req.ProviderData.(*govpsie.Client)
 	if !ok {
 		resp.Diagnostics.AddError(
-			"Unexpected Data Source Configuration Type",
+			"Unexpected Resource Configuration Type",
 			fmt.Sprintf("Expected *govpsie.Client, got %T. Please report  this issue to the provider developers.", req.ProviderData),
 		)
 
@@ -406,21 +406,6 @@ func (g *gatewayResource) Delete(ctx context.Context, req resource.DeleteRequest
 
 func (g *gatewayResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
 	resource.ImportStatePassthroughID(ctx, path.Root("identifier"), req, resp)
-}
-
-func (g *gatewayResource) GetDomainByName(ctx context.Context, domainName string) (*govpsie.Domain, error) {
-	domains, err := g.client.Domain.ListDomains(ctx, nil)
-	if err != nil {
-		return nil, err
-	}
-
-	for _, domain := range domains {
-		if domainName == domain.DomainName {
-			return &domain, nil
-		}
-	}
-
-	return nil, fmt.Errorf("domain with name %s not found", domainName)
 }
 
 func (g *gatewayResource) CreateAndReturnGateway(ctx context.Context, ipType, dcIdentifier string) (*govpsie.Gateway, error) {

--- a/internal/services/image/image_resource.go
+++ b/internal/services/image/image_resource.go
@@ -155,7 +155,7 @@ func (i *imageResource) Configure(_ context.Context, req resource.ConfigureReque
 	client, ok := req.ProviderData.(*govpsie.Client)
 	if !ok {
 		resp.Diagnostics.AddError(
-			"Unexpected Data Source Configuration Type",
+			"Unexpected Resource Configuration Type",
 			fmt.Sprintf("Expected *govpsie.Client, got %T. Please report  this issue to the provider developers.", req.ProviderData),
 		)
 

--- a/internal/services/kubernetes/kubernetes_group_source.go
+++ b/internal/services/kubernetes/kubernetes_group_source.go
@@ -198,7 +198,7 @@ func (k *kubernetesGroupResource) Configure(_ context.Context, req resource.Conf
 	client, ok := req.ProviderData.(*govpsie.Client)
 	if !ok {
 		resp.Diagnostics.AddError(
-			"Unexpected Data Source Configuration Type",
+			"Unexpected Resource Configuration Type",
 			fmt.Sprintf("Expected *govpsie.Client, got %T. Please report  this issue to the provider developers.", req.ProviderData),
 		)
 

--- a/internal/services/kubernetes/kubernetes_resource.go
+++ b/internal/services/kubernetes/kubernetes_resource.go
@@ -254,7 +254,7 @@ func (k *kubernetesResource) Configure(_ context.Context, req resource.Configure
 	client, ok := req.ProviderData.(*govpsie.Client)
 	if !ok {
 		resp.Diagnostics.AddError(
-			"Unexpected Data Source Configuration Type",
+			"Unexpected Resource Configuration Type",
 			fmt.Sprintf("Expected *govpsie.Client, got %T. Please report  this issue to the provider developers.", req.ProviderData),
 		)
 

--- a/internal/services/loadbalancer/loadbalancer_resource.go
+++ b/internal/services/loadbalancer/loadbalancer_resource.go
@@ -406,7 +406,7 @@ func (l *loadbalancerResource) Configure(_ context.Context, req resource.Configu
 	client, ok := req.ProviderData.(*govpsie.Client)
 	if !ok {
 		resp.Diagnostics.AddError(
-			"Unexpected Data Source Configuration Type",
+			"Unexpected Resource Configuration Type",
 			fmt.Sprintf("Expected *govpsie.Client, got %T. Please report  this issue to the provider developers.", req.ProviderData),
 		)
 

--- a/internal/services/project/project_resource.go
+++ b/internal/services/project/project_resource.go
@@ -114,7 +114,7 @@ func (i *projectResource) Configure(_ context.Context, req resource.ConfigureReq
 	client, ok := req.ProviderData.(*govpsie.Client)
 	if !ok {
 		resp.Diagnostics.AddError(
-			"Unexpected Data Source Configuration Type",
+			"Unexpected Resource Configuration Type",
 			fmt.Sprintf("Expected *govpsie.Client, got %T. Please report  this issue to the provider developers.", req.ProviderData),
 		)
 

--- a/internal/services/script/script_resource.go
+++ b/internal/services/script/script_resource.go
@@ -112,7 +112,7 @@ func (s *scriptResource) Configure(_ context.Context, req resource.ConfigureRequ
 	client, ok := req.ProviderData.(*govpsie.Client)
 	if !ok {
 		resp.Diagnostics.AddError(
-			"Unexpected Data Source Configuration Type",
+			"Unexpected Resource Configuration Type",
 			fmt.Sprintf("Expected *govpsie.Client, got %T. Please report  this issue to the provider developers.", req.ProviderData),
 		)
 

--- a/internal/services/server/server_resource.go
+++ b/internal/services/server/server_resource.go
@@ -620,7 +620,7 @@ func (s *serverResource) Configure(_ context.Context, req resource.ConfigureRequ
 	client, ok := req.ProviderData.(*govpsie.Client)
 	if !ok {
 		resp.Diagnostics.AddError(
-			"Unexpected Data Source Configuration Type",
+			"Unexpected Resource Configuration Type",
 			fmt.Sprintf("Expected *govpsie.Client, got %T. Please report  this issue to the provider developers.", req.ProviderData),
 		)
 

--- a/internal/services/snapshot/server_snapshot_resource.go
+++ b/internal/services/snapshot/server_snapshot_resource.go
@@ -209,7 +209,7 @@ func (s *serverSnapshotResource) Configure(_ context.Context, req resource.Confi
 	client, ok := req.ProviderData.(*govpsie.Client)
 	if !ok {
 		resp.Diagnostics.AddError(
-			"Unexpected Data Source Configuration Type",
+			"Unexpected Resource Configuration Type",
 			fmt.Sprintf("Expected *govpsie.Client, got %T. Please report  this issue to the provider developers.", req.ProviderData),
 		)
 

--- a/internal/services/sshkey/sshkey_resource.go
+++ b/internal/services/sshkey/sshkey_resource.go
@@ -100,7 +100,7 @@ func (s *sshkeyResource) Configure(_ context.Context, req resource.ConfigureRequ
 	client, ok := req.ProviderData.(*govpsie.Client)
 	if !ok {
 		resp.Diagnostics.AddError(
-			"Unexpected Data Source Configuration Type",
+			"Unexpected Resource Configuration Type",
 			fmt.Sprintf("Expected *govpsie.Client, got %T. Please report  this issue to the provider developers.", req.ProviderData),
 		)
 

--- a/internal/services/storage/storage_attachment_resource.go
+++ b/internal/services/storage/storage_attachment_resource.go
@@ -64,7 +64,7 @@ func (s *storageAttachmentResource) Configure(_ context.Context, req resource.Co
 	client, ok := req.ProviderData.(*govpsie.Client)
 	if !ok {
 		resp.Diagnostics.AddError(
-			"Unexpected Data Source Configuration Type",
+			"Unexpected Resource Configuration Type",
 			fmt.Sprintf("Expected *govpsie.Client, got %T. Please report  this issue to the provider developers.", req.ProviderData),
 		)
 

--- a/internal/services/storage/storage_resource.go
+++ b/internal/services/storage/storage_resource.go
@@ -181,7 +181,7 @@ func (s *storageResource) Configure(_ context.Context, req resource.ConfigureReq
 	client, ok := req.ProviderData.(*govpsie.Client)
 	if !ok {
 		resp.Diagnostics.AddError(
-			"Unexpected Data Source Configuration Type",
+			"Unexpected Resource Configuration Type",
 			fmt.Sprintf("Expected *govpsie.Client, got %T. Please report  this issue to the provider developers.", req.ProviderData),
 		)
 

--- a/internal/services/storage/storage_snapshot_resource.go
+++ b/internal/services/storage/storage_snapshot_resource.go
@@ -161,7 +161,7 @@ func (s *storageSnapshotResource) Configure(_ context.Context, req resource.Conf
 	client, ok := req.ProviderData.(*govpsie.Client)
 	if !ok {
 		resp.Diagnostics.AddError(
-			"Unexpected Data Source Configuration Type",
+			"Unexpected Resource Configuration Type",
 			fmt.Sprintf("Expected *govpsie.Client, got %T. Please report  this issue to the provider developers.", req.ProviderData),
 		)
 

--- a/internal/services/vpc/vpc_resoucre.go
+++ b/internal/services/vpc/vpc_resoucre.go
@@ -228,7 +228,7 @@ func (v *vpcResource) Configure(_ context.Context, req resource.ConfigureRequest
 	client, ok := req.ProviderData.(*govpsie.Client)
 	if !ok {
 		resp.Diagnostics.AddError(
-			"Unexpected Data Source Configuration Type",
+			"Unexpected Resource Configuration Type",
 			fmt.Sprintf("Expected *govpsie.Client, got %T. Please report  this issue to the provider developers.", req.ProviderData),
 		)
 


### PR DESCRIPTION
## Summary
- Fix inconsistent error messages in resource Configure() methods that incorrectly referenced "Data Source Configuration Type" instead of "Resource Configuration Type"
- Remove the unused GetDomainByName() helper function from gateway_resource.go

## Details
The Configure() method error message was semantically incorrect for resource configuration context. This fix ensures the error message accurately reflects that it's a resource configuration issue, not a data source configuration issue.

The GetDomainByName() function in the gateway resource has been superseded by other domain lookup mechanisms and is no longer used.

## Files Changed
- 17 resource files: corrected Configure() error messages
- gateway_resource.go: removed unused GetDomainByName() function

## Test Plan
- [ ] Verify provider builds successfully: `go build -v .`
- [ ] Run acceptance tests: `TF_ACC=1 go test ./... -v -timeout 120m`
- [ ] Run linter: `golangci-lint run`