### PR TITLE
fix: correct typos in error messages across all services

### DIFF
--- a/internal/services/accesstoken/accesstoken_resource.go
+++ b/internal/services/accesstoken/accesstoken_resource.go
@@ -189,6 +189,7 @@ func (a *accessTokenResource) Delete(ctx context.Context, req resource.DeleteReq
 			"Error deleting access token",
 			"couldn't delete access token, unexpected error: "+err.Error(),
 		)
+		return
 	}
 }
 

--- a/internal/services/backup/backup_data_source.go
+++ b/internal/services/backup/backup_data_source.go
@@ -160,7 +160,7 @@ func (b *backupDataSource) Configure(_ context.Context, req datasource.Configure
 	if !ok {
 		resp.Diagnostics.AddError(
 			"Unexpected Data Source Configuration Type",
-			fmt.Sprintf("Expected *govpsie.Client, got %T. Please report  this issue to the provider developers.", req.ProviderData),
+			fmt.Sprintf("Expected *govpsie.Client, got %T. Please report this issue to the provider developers.", req.ProviderData),
 		)
 
 		return

--- a/internal/services/backup/backup_policy_resource.go
+++ b/internal/services/backup/backup_policy_resource.go
@@ -290,6 +290,7 @@ func (b *backupPolicyResource) Delete(ctx context.Context, req resource.DeleteRe
 			"Error deleting backup policy",
 			"couldn't delete backup policy, unexpected error: "+err.Error(),
 		)
+		return
 	}
 }
 

--- a/internal/services/backup/backup_resource.go
+++ b/internal/services/backup/backup_resource.go
@@ -136,7 +136,7 @@ func (b *backupResource) Configure(_ context.Context, req resource.ConfigureRequ
 	if !ok {
 		resp.Diagnostics.AddError(
 			"Unexpected Resource Configuration Type",
-			fmt.Sprintf("Expected *govpsie.Client, got %T. Please report  this issue to the provider developers.", req.ProviderData),
+			fmt.Sprintf("Expected *govpsie.Client, got %T. Please report this issue to the provider developers.", req.ProviderData),
 		)
 
 		return

--- a/internal/services/bucket/bucket_resource.go
+++ b/internal/services/bucket/bucket_resource.go
@@ -254,6 +254,7 @@ func (b *bucketResource) Delete(ctx context.Context, req resource.DeleteRequest,
 			"Error deleting bucket",
 			"couldn't delete bucket, unexpected error: "+err.Error(),
 		)
+		return
 	}
 }
 

--- a/internal/services/domain/dns_record_resource.go
+++ b/internal/services/domain/dns_record_resource.go
@@ -223,5 +223,6 @@ func (d *dnsRecordResource) Delete(ctx context.Context, req resource.DeleteReque
 			"Error deleting DNS record",
 			"couldn't delete DNS record, unexpected error: "+err.Error(),
 		)
+		return
 	}
 }

--- a/internal/services/domain/domain_data_source.go
+++ b/internal/services/domain/domain_data_source.go
@@ -115,7 +115,7 @@ func (d *domainDataSource) Configure(_ context.Context, req datasource.Configure
 	if !ok {
 		resp.Diagnostics.AddError(
 			"Unexpected Data Source Configuration Type",
-			fmt.Sprintf("Expected *govpsie.Client, got %T. Please report  this issue to the provider developers.", req.ProviderData),
+			fmt.Sprintf("Expected *govpsie.Client, got %T. Please report this issue to the provider developers.", req.ProviderData),
 		)
 
 		return

--- a/internal/services/domain/domain_resource.go
+++ b/internal/services/domain/domain_resource.go
@@ -94,7 +94,7 @@ func (d *domainResource) Configure(_ context.Context, req resource.ConfigureRequ
 	if !ok {
 		resp.Diagnostics.AddError(
 			"Unexpected Resource Configuration Type",
-			fmt.Sprintf("Expected *govpsie.Client, got %T. Please report  this issue to the provider developers.", req.ProviderData),
+			fmt.Sprintf("Expected *govpsie.Client, got %T. Please report this issue to the provider developers.", req.ProviderData),
 		)
 
 		return

--- a/internal/services/domain/reverse_dns_resource.go
+++ b/internal/services/domain/reverse_dns_resource.go
@@ -183,5 +183,6 @@ func (r *reverseDnsResource) Delete(ctx context.Context, req resource.DeleteRequ
 			"Error deleting reverse DNS",
 			"couldn't delete reverse DNS, unexpected error: "+err.Error(),
 		)
+		return
 	}
 }

--- a/internal/services/fip/fip_resource.go
+++ b/internal/services/fip/fip_resource.go
@@ -194,5 +194,6 @@ func (f *fipResource) Delete(ctx context.Context, req resource.DeleteRequest, re
 			"Error deleting floating IP",
 			"couldn't delete floating IP, unexpected error: "+err.Error(),
 		)
+		return
 	}
 }

--- a/internal/services/firewall/firewall_attachment_resource.go
+++ b/internal/services/firewall/firewall_attachment_resource.go
@@ -146,5 +146,6 @@ func (f *firewallAttachmentResource) Delete(ctx context.Context, req resource.De
 			"Error detaching firewall from VM",
 			"couldn't detach firewall from VM, unexpected error: "+err.Error(),
 		)
+		return
 	}
 }

--- a/internal/services/firewall/firewall_data_source.go
+++ b/internal/services/firewall/firewall_data_source.go
@@ -432,7 +432,7 @@ func (g *firewallDataSource) Configure(_ context.Context, req datasource.Configu
 	if !ok {
 		resp.Diagnostics.AddError(
 			"Unexpected Data Source Configuration Type",
-			fmt.Sprintf("Expected *govpsie.Client, got %T. Please report  this issue to the provider developers.", req.ProviderData),
+			fmt.Sprintf("Expected *govpsie.Client, got %T. Please report this issue to the provider developers.", req.ProviderData),
 		)
 
 		return

--- a/internal/services/firewall/firewall_resource.go
+++ b/internal/services/firewall/firewall_resource.go
@@ -606,6 +606,7 @@ func (f *firewallResource) Delete(ctx context.Context, req resource.DeleteReques
 			"Error deleting firewall",
 			"couldn't delete firewall, unexpected error: "+err.Error(),
 		)
+		return
 	}
 }
 

--- a/internal/services/firewall/firewall_resource.go
+++ b/internal/services/firewall/firewall_resource.go
@@ -292,7 +292,7 @@ func (g *firewallResource) Configure(_ context.Context, req resource.ConfigureRe
 	if !ok {
 		resp.Diagnostics.AddError(
 			"Unexpected Resource Configuration Type",
-			fmt.Sprintf("Expected *govpsie.Client, got %T. Please report  this issue to the provider developers.", req.ProviderData),
+			fmt.Sprintf("Expected *govpsie.Client, got %T. Please report this issue to the provider developers.", req.ProviderData),
 		)
 
 		return

--- a/internal/services/gateway/gateway_data_source.go
+++ b/internal/services/gateway/gateway_data_source.go
@@ -205,7 +205,7 @@ func (g *gatewayDataSource) Configure(_ context.Context, req datasource.Configur
 	if !ok {
 		resp.Diagnostics.AddError(
 			"Unexpected Data Source Configuration Type",
-			fmt.Sprintf("Expected *govpsie.Client, got %T. Please report  this issue to the provider developers.", req.ProviderData),
+			fmt.Sprintf("Expected *govpsie.Client, got %T. Please report this issue to the provider developers.", req.ProviderData),
 		)
 
 		return

--- a/internal/services/gateway/gateway_resource.go
+++ b/internal/services/gateway/gateway_resource.go
@@ -401,6 +401,7 @@ func (g *gatewayResource) Delete(ctx context.Context, req resource.DeleteRequest
 			"Error deleting gateway",
 			"couldn't delete gateway, unexpected error: "+err.Error(),
 		)
+		return
 	}
 }
 

--- a/internal/services/gateway/gateway_resource.go
+++ b/internal/services/gateway/gateway_resource.go
@@ -185,7 +185,7 @@ func (g *gatewayResource) Configure(_ context.Context, req resource.ConfigureReq
 	if !ok {
 		resp.Diagnostics.AddError(
 			"Unexpected Resource Configuration Type",
-			fmt.Sprintf("Expected *govpsie.Client, got %T. Please report  this issue to the provider developers.", req.ProviderData),
+			fmt.Sprintf("Expected *govpsie.Client, got %T. Please report this issue to the provider developers.", req.ProviderData),
 		)
 
 		return

--- a/internal/services/image/image_data_source.go
+++ b/internal/services/image/image_data_source.go
@@ -160,7 +160,7 @@ func (i *imageDataSource) Configure(_ context.Context, req datasource.ConfigureR
 	if !ok {
 		resp.Diagnostics.AddError(
 			"Unexpected Data Source Configuration Type",
-			fmt.Sprintf("Expected *govpsie.Client, got %T. Please report  this issue to the provider developers.", req.ProviderData),
+			fmt.Sprintf("Expected *govpsie.Client, got %T. Please report this issue to the provider developers.", req.ProviderData),
 		)
 
 		return

--- a/internal/services/image/image_resource.go
+++ b/internal/services/image/image_resource.go
@@ -156,7 +156,7 @@ func (i *imageResource) Configure(_ context.Context, req resource.ConfigureReque
 	if !ok {
 		resp.Diagnostics.AddError(
 			"Unexpected Resource Configuration Type",
-			fmt.Sprintf("Expected *govpsie.Client, got %T. Please report  this issue to the provider developers.", req.ProviderData),
+			fmt.Sprintf("Expected *govpsie.Client, got %T. Please report this issue to the provider developers.", req.ProviderData),
 		)
 
 		return
@@ -202,7 +202,7 @@ func (i *imageResource) Create(ctx context.Context, req resource.CreateRequest, 
 		image, ready, err := i.checkResourceStatus(ctx, plan.ImageLabel.ValueString())
 		if err != nil {
 			//  return fmt.Errorf("Timeout waiting for resource to become ready")
-			resp.Diagnostics.AddError("Error cheking status of resource", err.Error())
+			resp.Diagnostics.AddError("Error checking status of resource", err.Error())
 			return
 		}
 
@@ -255,7 +255,7 @@ func (i *imageResource) Read(ctx context.Context, req resource.ReadRequest, resp
 
 		resp.Diagnostics.AddError(
 			"Error reading vpsie image",
-			"Could't read vpsie image identifier "+state.Identifier.ValueString()+": "+err.Error(),
+			"Couldn't read vpsie image identifier "+state.Identifier.ValueString()+": "+err.Error(),
 		)
 		return
 	}

--- a/internal/services/kubernetes/kubernetes_data_source.go
+++ b/internal/services/kubernetes/kubernetes_data_source.go
@@ -160,7 +160,7 @@ func (k *kubernetesDataSource) Configure(_ context.Context, req datasource.Confi
 	if !ok {
 		resp.Diagnostics.AddError(
 			"Unexpected Data Source Configuration Type",
-			fmt.Sprintf("Expected *govpsie.Client, got %T. Please report  this issue to the provider developers.", req.ProviderData),
+			fmt.Sprintf("Expected *govpsie.Client, got %T. Please report this issue to the provider developers.", req.ProviderData),
 		)
 
 		return

--- a/internal/services/kubernetes/kubernetes_group_data_source.go
+++ b/internal/services/kubernetes/kubernetes_group_data_source.go
@@ -201,7 +201,7 @@ func (k *kubernetesGroupDataSource) Configure(_ context.Context, req datasource.
 	if !ok {
 		resp.Diagnostics.AddError(
 			"Unexpected Data Source Configuration Type",
-			fmt.Sprintf("Expected *govpsie.Client, got %T. Please report  this issue to the provider developers.", req.ProviderData),
+			fmt.Sprintf("Expected *govpsie.Client, got %T. Please report this issue to the provider developers.", req.ProviderData),
 		)
 
 		return

--- a/internal/services/kubernetes/kubernetes_group_source.go
+++ b/internal/services/kubernetes/kubernetes_group_source.go
@@ -199,7 +199,7 @@ func (k *kubernetesGroupResource) Configure(_ context.Context, req resource.Conf
 	if !ok {
 		resp.Diagnostics.AddError(
 			"Unexpected Resource Configuration Type",
-			fmt.Sprintf("Expected *govpsie.Client, got %T. Please report  this issue to the provider developers.", req.ProviderData),
+			fmt.Sprintf("Expected *govpsie.Client, got %T. Please report this issue to the provider developers.", req.ProviderData),
 		)
 
 		return
@@ -281,7 +281,7 @@ func (k *kubernetesGroupResource) Read(ctx context.Context, req resource.ReadReq
 
 		resp.Diagnostics.AddError(
 			"Error reading vpsie kubernetes group",
-			"Could't read vpsie kubernetes group identifier "+state.Identifier.ValueString()+": "+err.Error(),
+			"Couldn't read vpsie kubernetes group identifier "+state.Identifier.ValueString()+": "+err.Error(),
 		)
 		return
 	}

--- a/internal/services/kubernetes/kubernetes_resource.go
+++ b/internal/services/kubernetes/kubernetes_resource.go
@@ -255,7 +255,7 @@ func (k *kubernetesResource) Configure(_ context.Context, req resource.Configure
 	if !ok {
 		resp.Diagnostics.AddError(
 			"Unexpected Resource Configuration Type",
-			fmt.Sprintf("Expected *govpsie.Client, got %T. Please report  this issue to the provider developers.", req.ProviderData),
+			fmt.Sprintf("Expected *govpsie.Client, got %T. Please report this issue to the provider developers.", req.ProviderData),
 		)
 
 		return
@@ -312,7 +312,7 @@ func (k *kubernetesResource) Create(ctx context.Context, req resource.CreateRequ
 		k8s, ready, err := k.checkResourceStatus(ctx, plan.ClusterName.ValueString())
 		if err != nil {
 			//  return fmt.Errorf("Timeout waiting for resource to become ready")
-			resp.Diagnostics.AddError("Error cheking status of resource", err.Error())
+			resp.Diagnostics.AddError("Error checking status of resource", err.Error())
 			return
 		}
 
@@ -379,7 +379,7 @@ func (k *kubernetesResource) Read(ctx context.Context, req resource.ReadRequest,
 
 		resp.Diagnostics.AddError(
 			"Error reading vpsie kubernetes",
-			"Could't read vpsie kubernetes identifier "+state.Identifier.ValueString()+": "+err.Error(),
+			"Couldn't read vpsie kubernetes identifier "+state.Identifier.ValueString()+": "+err.Error(),
 		)
 		return
 	}

--- a/internal/services/loadbalancer/loadbalancer_data_source.go
+++ b/internal/services/loadbalancer/loadbalancer_data_source.go
@@ -160,7 +160,7 @@ func (l *loadbalancerDataSource) Configure(_ context.Context, req datasource.Con
 	if !ok {
 		resp.Diagnostics.AddError(
 			"Unexpected Data Source Configuration Type",
-			fmt.Sprintf("Expected *govpsie.Client, got %T. Please report  this issue to the provider developers.", req.ProviderData),
+			fmt.Sprintf("Expected *govpsie.Client, got %T. Please report this issue to the provider developers.", req.ProviderData),
 		)
 
 		return

--- a/internal/services/loadbalancer/loadbalancer_resource.go
+++ b/internal/services/loadbalancer/loadbalancer_resource.go
@@ -407,7 +407,7 @@ func (l *loadbalancerResource) Configure(_ context.Context, req resource.Configu
 	if !ok {
 		resp.Diagnostics.AddError(
 			"Unexpected Resource Configuration Type",
-			fmt.Sprintf("Expected *govpsie.Client, got %T. Please report  this issue to the provider developers.", req.ProviderData),
+			fmt.Sprintf("Expected *govpsie.Client, got %T. Please report this issue to the provider developers.", req.ProviderData),
 		)
 
 		return
@@ -505,7 +505,7 @@ func (l *loadbalancerResource) Create(ctx context.Context, req resource.CreateRe
 		lb, ready, err := l.checkResourceStatus(ctx, plan.LBName.ValueString())
 		if err != nil {
 			//  return fmt.Errorf("Timeout waiting for resource to become ready")
-			resp.Diagnostics.AddError("Error cheking status of resource", err.Error())
+			resp.Diagnostics.AddError("Error checking status of resource", err.Error())
 			return
 		}
 
@@ -621,7 +621,7 @@ func (l *loadbalancerResource) Read(ctx context.Context, req resource.ReadReques
 
 		resp.Diagnostics.AddError(
 			"Error reading vpsie loadbalancer",
-			"Could't read vpsie loadbalancer identifier "+state.Identifier.ValueString()+": "+err.Error(),
+			"Couldn't read vpsie loadbalancer identifier "+state.Identifier.ValueString()+": "+err.Error(),
 		)
 		return
 	}

--- a/internal/services/monitoring/monitoring_rule_resource.go
+++ b/internal/services/monitoring/monitoring_rule_resource.go
@@ -299,6 +299,7 @@ func (m *monitoringRuleResource) Delete(ctx context.Context, req resource.Delete
 			"Error deleting monitoring rule",
 			"couldn't delete monitoring rule, unexpected error: "+err.Error(),
 		)
+		return
 	}
 }
 

--- a/internal/services/project/project_data_source.go
+++ b/internal/services/project/project_data_source.go
@@ -130,7 +130,7 @@ func (p *projectDataSource) Configure(_ context.Context, req datasource.Configur
 	if !ok {
 		resp.Diagnostics.AddError(
 			"Unexpected Data Source Configuration Type",
-			fmt.Sprintf("Expected *govpsie.Client, got %T. Please report  this issue to the provider developers.", req.ProviderData),
+			fmt.Sprintf("Expected *govpsie.Client, got %T. Please report this issue to the provider developers.", req.ProviderData),
 		)
 
 		return

--- a/internal/services/project/project_resource.go
+++ b/internal/services/project/project_resource.go
@@ -115,7 +115,7 @@ func (i *projectResource) Configure(_ context.Context, req resource.ConfigureReq
 	if !ok {
 		resp.Diagnostics.AddError(
 			"Unexpected Resource Configuration Type",
-			fmt.Sprintf("Expected *govpsie.Client, got %T. Please report  this issue to the provider developers.", req.ProviderData),
+			fmt.Sprintf("Expected *govpsie.Client, got %T. Please report this issue to the provider developers.", req.ProviderData),
 		)
 
 		return

--- a/internal/services/script/script_data_source.go
+++ b/internal/services/script/script_data_source.go
@@ -133,7 +133,7 @@ func (s *scriptDataSource) Configure(_ context.Context, req datasource.Configure
 	if !ok {
 		resp.Diagnostics.AddError(
 			"Unexpected Data Source Configuration Type",
-			fmt.Sprintf("Expected *govpsie.Client, got %T. Please report  this issue to the provider developers.", req.ProviderData),
+			fmt.Sprintf("Expected *govpsie.Client, got %T. Please report this issue to the provider developers.", req.ProviderData),
 		)
 
 		return

--- a/internal/services/script/script_resource.go
+++ b/internal/services/script/script_resource.go
@@ -113,7 +113,7 @@ func (s *scriptResource) Configure(_ context.Context, req resource.ConfigureRequ
 	if !ok {
 		resp.Diagnostics.AddError(
 			"Unexpected Resource Configuration Type",
-			fmt.Sprintf("Expected *govpsie.Client, got %T. Please report  this issue to the provider developers.", req.ProviderData),
+			fmt.Sprintf("Expected *govpsie.Client, got %T. Please report this issue to the provider developers.", req.ProviderData),
 		)
 
 		return

--- a/internal/services/server/server_data_source.go
+++ b/internal/services/server/server_data_source.go
@@ -444,7 +444,7 @@ func (s *serverDataSource) Configure(_ context.Context, req datasource.Configure
 	if !ok {
 		resp.Diagnostics.AddError(
 			"Unexpected Data Source Configuration Type",
-			fmt.Sprintf("Expected *govpsie.Client, got %T. Please report  this issue to the provider developers.", req.ProviderData),
+			fmt.Sprintf("Expected *govpsie.Client, got %T. Please report this issue to the provider developers.", req.ProviderData),
 		)
 
 		return

--- a/internal/services/server/server_resource.go
+++ b/internal/services/server/server_resource.go
@@ -621,7 +621,7 @@ func (s *serverResource) Configure(_ context.Context, req resource.ConfigureRequ
 	if !ok {
 		resp.Diagnostics.AddError(
 			"Unexpected Resource Configuration Type",
-			fmt.Sprintf("Expected *govpsie.Client, got %T. Please report  this issue to the provider developers.", req.ProviderData),
+			fmt.Sprintf("Expected *govpsie.Client, got %T. Please report this issue to the provider developers.", req.ProviderData),
 		)
 
 		return
@@ -692,7 +692,7 @@ func (s *serverResource) Create(ctx context.Context, req resource.CreateRequest,
 		server, ready, err := s.checkResourceStatus(ctx, plan.Hostname.ValueString())
 		if err != nil {
 			//  return fmt.Errorf("Timeout waiting for resource to become ready")
-			resp.Diagnostics.AddError("Error cheking status of resource", err.Error())
+			resp.Diagnostics.AddError("Error checking status of resource", err.Error())
 			return
 		}
 

--- a/internal/services/snapshot/server_snapshot_data_source.go
+++ b/internal/services/snapshot/server_snapshot_data_source.go
@@ -208,7 +208,7 @@ func (s *serverSnapshotDataSource) Configure(_ context.Context, req datasource.C
 	if !ok {
 		resp.Diagnostics.AddError(
 			"Unexpected Data Source Configuration Type",
-			fmt.Sprintf("Expected *govpsie.Client, got %T. Please report  this issue to the provider developers.", req.ProviderData),
+			fmt.Sprintf("Expected *govpsie.Client, got %T. Please report this issue to the provider developers.", req.ProviderData),
 		)
 
 		return

--- a/internal/services/snapshot/server_snapshot_resource.go
+++ b/internal/services/snapshot/server_snapshot_resource.go
@@ -210,7 +210,7 @@ func (s *serverSnapshotResource) Configure(_ context.Context, req resource.Confi
 	if !ok {
 		resp.Diagnostics.AddError(
 			"Unexpected Resource Configuration Type",
-			fmt.Sprintf("Expected *govpsie.Client, got %T. Please report  this issue to the provider developers.", req.ProviderData),
+			fmt.Sprintf("Expected *govpsie.Client, got %T. Please report this issue to the provider developers.", req.ProviderData),
 		)
 
 		return

--- a/internal/services/snapshot/snapshot_policy_resource.go
+++ b/internal/services/snapshot/snapshot_policy_resource.go
@@ -292,6 +292,7 @@ func (s *snapshotPolicyResource) Delete(ctx context.Context, req resource.Delete
 			"Error deleting snapshot policy",
 			"couldn't delete snapshot policy, unexpected error: "+err.Error(),
 		)
+		return
 	}
 }
 

--- a/internal/services/sshkey/sshkey_data_source.go
+++ b/internal/services/sshkey/sshkey_data_source.go
@@ -128,7 +128,7 @@ func (s *sshKeyDataSource) Configure(_ context.Context, req datasource.Configure
 	if !ok {
 		resp.Diagnostics.AddError(
 			"Unexpected Data Source Configuration Type",
-			fmt.Sprintf("Expected *govpsie.Client, got %T. Please report  this issue to the provider developers.", req.ProviderData),
+			fmt.Sprintf("Expected *govpsie.Client, got %T. Please report this issue to the provider developers.", req.ProviderData),
 		)
 
 		return

--- a/internal/services/sshkey/sshkey_resource.go
+++ b/internal/services/sshkey/sshkey_resource.go
@@ -101,7 +101,7 @@ func (s *sshkeyResource) Configure(_ context.Context, req resource.ConfigureRequ
 	if !ok {
 		resp.Diagnostics.AddError(
 			"Unexpected Resource Configuration Type",
-			fmt.Sprintf("Expected *govpsie.Client, got %T. Please report  this issue to the provider developers.", req.ProviderData),
+			fmt.Sprintf("Expected *govpsie.Client, got %T. Please report this issue to the provider developers.", req.ProviderData),
 		)
 
 		return

--- a/internal/services/storage/storage_attachment_resource.go
+++ b/internal/services/storage/storage_attachment_resource.go
@@ -65,7 +65,7 @@ func (s *storageAttachmentResource) Configure(_ context.Context, req resource.Co
 	if !ok {
 		resp.Diagnostics.AddError(
 			"Unexpected Resource Configuration Type",
-			fmt.Sprintf("Expected *govpsie.Client, got %T. Please report  this issue to the provider developers.", req.ProviderData),
+			fmt.Sprintf("Expected *govpsie.Client, got %T. Please report this issue to the provider developers.", req.ProviderData),
 		)
 
 		return

--- a/internal/services/storage/storage_data_source.go
+++ b/internal/services/storage/storage_data_source.go
@@ -202,7 +202,7 @@ func (s *storageDataSource) Configure(_ context.Context, req datasource.Configur
 	if !ok {
 		resp.Diagnostics.AddError(
 			"Unexpected Data Source Configuration Type",
-			fmt.Sprintf("Expected *govpsie.Client, got %T. Please report  this issue to the provider developers.", req.ProviderData),
+			fmt.Sprintf("Expected *govpsie.Client, got %T. Please report this issue to the provider developers.", req.ProviderData),
 		)
 
 		return

--- a/internal/services/storage/storage_resource.go
+++ b/internal/services/storage/storage_resource.go
@@ -182,7 +182,7 @@ func (s *storageResource) Configure(_ context.Context, req resource.ConfigureReq
 	if !ok {
 		resp.Diagnostics.AddError(
 			"Unexpected Resource Configuration Type",
-			fmt.Sprintf("Expected *govpsie.Client, got %T. Please report  this issue to the provider developers.", req.ProviderData),
+			fmt.Sprintf("Expected *govpsie.Client, got %T. Please report this issue to the provider developers.", req.ProviderData),
 		)
 
 		return

--- a/internal/services/storage/storage_snapshot_data_resource.go
+++ b/internal/services/storage/storage_snapshot_data_resource.go
@@ -169,7 +169,7 @@ func (s *storageSnapshotDataSource) Configure(_ context.Context, req datasource.
 	if !ok {
 		resp.Diagnostics.AddError(
 			"Unexpected Data Source Configuration Type",
-			fmt.Sprintf("Expected *govpsie.Client, got %T. Please report  this issue to the provider developers.", req.ProviderData),
+			fmt.Sprintf("Expected *govpsie.Client, got %T. Please report this issue to the provider developers.", req.ProviderData),
 		)
 
 		return

--- a/internal/services/storage/storage_snapshot_resource.go
+++ b/internal/services/storage/storage_snapshot_resource.go
@@ -162,7 +162,7 @@ func (s *storageSnapshotResource) Configure(_ context.Context, req resource.Conf
 	if !ok {
 		resp.Diagnostics.AddError(
 			"Unexpected Resource Configuration Type",
-			fmt.Sprintf("Expected *govpsie.Client, got %T. Please report  this issue to the provider developers.", req.ProviderData),
+			fmt.Sprintf("Expected *govpsie.Client, got %T. Please report this issue to the provider developers.", req.ProviderData),
 		)
 
 		return

--- a/internal/services/vpc/vpc_data_source.go
+++ b/internal/services/vpc/vpc_data_source.go
@@ -211,7 +211,7 @@ func (v *vpcDataSource) Configure(_ context.Context, req datasource.ConfigureReq
 	if !ok {
 		resp.Diagnostics.AddError(
 			"Unexpected Data Source Configuration Type",
-			fmt.Sprintf("Expected *govpsie.Client, got %T. Please report  this issue to the provider developers.", req.ProviderData),
+			fmt.Sprintf("Expected *govpsie.Client, got %T. Please report this issue to the provider developers.", req.ProviderData),
 		)
 
 		return

--- a/internal/services/vpc/vpc_resoucre.go
+++ b/internal/services/vpc/vpc_resoucre.go
@@ -229,7 +229,7 @@ func (v *vpcResource) Configure(_ context.Context, req resource.ConfigureRequest
 	if !ok {
 		resp.Diagnostics.AddError(
 			"Unexpected Resource Configuration Type",
-			fmt.Sprintf("Expected *govpsie.Client, got %T. Please report  this issue to the provider developers.", req.ProviderData),
+			fmt.Sprintf("Expected *govpsie.Client, got %T. Please report this issue to the provider developers.", req.ProviderData),
 		)
 
 		return

--- a/internal/services/vpc/vpc_server_assignment_resource.go
+++ b/internal/services/vpc/vpc_server_assignment_resource.go
@@ -180,5 +180,6 @@ func (v *vpcServerAssignmentResource) Delete(ctx context.Context, req resource.D
 			"Error releasing VPC server assignment",
 			"couldn't release private IP, unexpected error: "+err.Error(),
 		)
+		return
 	}
 }


### PR DESCRIPTION
## Summary
- Fixed double space in \"Please report  this issue\" → \"Please report this issue\" across 33 files
- Fixed \"cheking\" → \"checking\" in 4 resource files
- Fixed \"Could't\" → \"Couldn't\" in 4 resource files

## Test plan
- [x] `go build ./...` passes
- [x] No remaining typo occurrences (verified with grep)
- [ ] CI checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)