### PR TITLE
Fix nil pointer in ListDomains and access token test length

### DIFF
--- a/internal/services/accesstoken/accesstoken_resource_test.go
+++ b/internal/services/accesstoken/accesstoken_resource_test.go
@@ -39,7 +39,7 @@ func testAccAccessTokenConfig(name, expiration string) string {
 	return fmt.Sprintf(`
 resource "vpsie_access_token" "test" {
   name            = %q
-  access_token    = "tf-acc-test-token-value"
+  access_token    = "tf-acc-test-token-value-that-is-long-enough-to-meet-the-64-char-minimum"
   expiration_date = %q
 }
 `, name, expiration)

--- a/internal/services/domain/domain_data_source.go
+++ b/internal/services/domain/domain_data_source.go
@@ -75,7 +75,7 @@ func (d *domainDataSource) Schema(_ context.Context, _ datasource.SchemaRequest,
 func (d *domainDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
 	var state domainDataSourceModel
 
-	domains, err := d.client.Domain.ListDomains(ctx, nil)
+	domains, err := d.client.Domain.ListDomains(ctx, &govpsie.ListOptions{Page: 0, PerPage: 50})
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Error Getting domains",

--- a/internal/services/domain/domain_resource.go
+++ b/internal/services/domain/domain_resource.go
@@ -209,7 +209,7 @@ func (d *domainResource) ImportState(ctx context.Context, req resource.ImportSta
 }
 
 func (d *domainResource) GetDomainByName(ctx context.Context, domainName string) (*govpsie.Domain, error) {
-	domains, err := d.client.Domain.ListDomains(ctx, nil)
+	domains, err := d.client.Domain.ListDomains(ctx, &govpsie.ListOptions{Page: 0, PerPage: 50})
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Summary

- **Fix domain nil pointer crash**: Pass a valid `ListOptions` to `ListDomains` instead of `nil`, which caused a nil pointer dereference in the govpsie SDK. Affects both the resource and data source.
- **Fix access token test**: Use a 64+ character token value to meet the API's minimum length requirement.

## Test plan

- [ ] Verify `go build -v .` succeeds
- [ ] Run domain acceptance test locally: `TF_ACC=1 go test ./internal/services/domain/... -v -timeout 120m`
- [ ] Run access token acceptance test locally: `TF_ACC=1 go test ./internal/services/accesstoken/... -v -timeout 120m`

🤖 Generated with [Claude Code](https://claude.com/claude-code)