### PR TITLE
feat(accesstoken): add status field and use local SDK fixes

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,8 +13,6 @@ require (
 	golang.org/x/oauth2 v0.34.0
 )
 
-replace github.com/vpsie/govpsie => /Users/zozo/projects/govpsie
-
 require (
 	github.com/BurntSushi/toml v1.2.1 // indirect
 	github.com/Kunde21/markdownfmt/v3 v3.1.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,8 @@ require (
 	golang.org/x/oauth2 v0.34.0
 )
 
+replace github.com/vpsie/govpsie => /Users/zozo/projects/govpsie
+
 require (
 	github.com/BurntSushi/toml v1.2.1 // indirect
 	github.com/Kunde21/markdownfmt/v3 v3.1.0 // indirect

--- a/internal/services/accesstoken/accesstoken_resource.go
+++ b/internal/services/accesstoken/accesstoken_resource.go
@@ -27,6 +27,7 @@ type accessTokenResourceModel struct {
 	AccessToken    types.String `tfsdk:"access_token"`
 	ExpirationDate types.String `tfsdk:"expiration_date"`
 	CreatedOn      types.String `tfsdk:"created_on"`
+	Status         types.String `tfsdk:"status"`
 }
 
 func NewAccessTokenResource() resource.Resource {
@@ -65,6 +66,10 @@ func (a *accessTokenResource) Schema(_ context.Context, _ resource.SchemaRequest
 					stringplanmodifier.UseStateForUnknown(),
 				},
 			},
+			"status": schema.StringAttribute{
+				Optional: true,
+				Computed: true,
+			},
 		},
 	}
 }
@@ -94,7 +99,7 @@ func (a *accessTokenResource) Create(ctx context.Context, req resource.CreateReq
 		return
 	}
 
-	err := a.client.AccessToken.Create(ctx, plan.Name.ValueString(), plan.AccessToken.ValueString(), plan.ExpirationDate.ValueString())
+	err := a.client.AccessToken.Create(ctx, plan.Name.ValueString(), plan.AccessToken.ValueString(), plan.ExpirationDate.ValueString(), plan.Status.ValueString())
 	if err != nil {
 		resp.Diagnostics.AddError("Error creating access token", err.Error())
 		return
@@ -108,6 +113,7 @@ func (a *accessTokenResource) Create(ctx context.Context, req resource.CreateReq
 
 	plan.Identifier = types.StringValue(token.AccessTokenIdentifier)
 	plan.CreatedOn = types.StringValue(token.CreatedOn)
+	plan.Status = types.StringValue(token.Status)
 
 	diags = resp.State.Set(ctx, plan)
 	resp.Diagnostics.Append(diags...)
@@ -133,6 +139,7 @@ func (a *accessTokenResource) Read(ctx context.Context, req resource.ReadRequest
 			state.Name = types.StringValue(token.Name)
 			state.ExpirationDate = types.StringValue(token.ExpirationDate)
 			state.CreatedOn = types.StringValue(token.CreatedOn)
+			state.Status = types.StringValue(token.Status)
 			found = true
 			break
 		}

--- a/internal/services/accesstoken/accesstoken_resource_test.go
+++ b/internal/services/accesstoken/accesstoken_resource_test.go
@@ -41,6 +41,7 @@ resource "vpsie_access_token" "test" {
   name            = %q
   access_token    = "tf-acc-test-token-value-that-is-long-enough-to-meet-the-64-char-minimum"
   expiration_date = %q
+  status          = "active"
 }
 `, name, expiration)
 }


### PR DESCRIPTION
## Summary

- Add `Status` field (Optional + Computed) to the access token resource model, schema, and CRUD operations
- Add `go.mod` replace directive to use local govpsie SDK with bug fixes
- Update acceptance test config to include `status = "active"`

Depends on SDK PR: vpsie/govpsie (nil pointer guards, UnmarshalJSON for data:false, access token status field)

## Test plan

- [ ] `go build -v .` compiles cleanly
- [ ] Access token acceptance tests pass with status field
- [ ] Existing resources unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)