### PR TITLE
Fix CI lint errors from production readiness PR

### DIFF
--- a/internal/services/accesstoken/accesstoken_unit_test.go
+++ b/internal/services/accesstoken/accesstoken_unit_test.go
@@ -52,9 +52,7 @@ func TestUnitAccessTokenAPI_MockSatisfiesInterface(t *testing.T) {
 	}
 
 	var api AccessTokenAPI = mock
-	if api == nil {
-		t.Fatal("expected mock to satisfy AccessTokenAPI interface")
-	}
+	_ = api // compile-time interface satisfaction verified by var _ above
 }
 
 func TestUnitAccessTokenAPI_GetTokenByName(t *testing.T) {
@@ -98,7 +96,7 @@ func TestUnitAccessTokenAPI_GetTokenByName(t *testing.T) {
 			}
 
 			r := &accessTokenResource{client: mock}
-			token, err := r.GetTokenByName(context.Background(), tt.tokenName)
+			token, err := r.GetTokenByName(t.Context(), tt.tokenName)
 
 			if tt.expectErr && err == nil {
 				t.Fatal("expected error, got nil")
@@ -126,7 +124,7 @@ func TestUnitAccessTokenAPI_Delete(t *testing.T) {
 		},
 	}
 
-	err := mock.Delete(context.Background(), "token-id-123")
+	err := mock.Delete(t.Context(), "token-id-123")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -143,7 +141,7 @@ func TestUnitAccessTokenAPI_ListError(t *testing.T) {
 	}
 
 	r := &accessTokenResource{client: mock}
-	_, err := r.GetTokenByName(context.Background(), "any-token")
+	_, err := r.GetTokenByName(t.Context(), "any-token")
 	if err == nil {
 		t.Fatal("expected error, got nil")
 	}

--- a/internal/services/backup/backup_unit_test.go
+++ b/internal/services/backup/backup_unit_test.go
@@ -79,16 +79,16 @@ func TestUnitBackupAPI_MockSatisfiesInterface(t *testing.T) {
 		DeleteBackupFn:       func(ctx context.Context, backupIdentifier, deleteReason, deleteNote string) error { return nil },
 		CreateBackupPolicyFn: func(ctx context.Context, createReq *govpsie.CreateBackupPolicyReq) error { return nil },
 		GetBackupPolicyFn:    func(ctx context.Context, identifier string) (*govpsie.BackupPolicy, error) { return nil, nil },
-		ListBackupPoliciesFn: func(ctx context.Context, options *govpsie.ListOptions) ([]govpsie.BackupPolicyListDetail, error) { return nil, nil },
+		ListBackupPoliciesFn: func(ctx context.Context, options *govpsie.ListOptions) ([]govpsie.BackupPolicyListDetail, error) {
+			return nil, nil
+		},
 		AttachBackupPolicyFn: func(ctx context.Context, policyId string, vms []string) error { return nil },
 		DetachBackupPolicyFn: func(ctx context.Context, policyId string, vms []string) error { return nil },
 		DeleteBackupPolicyFn: func(ctx context.Context, policyId, identifier string) error { return nil },
 	}
 
 	var api BackupAPI = mock
-	if api == nil {
-		t.Fatal("expected mock to satisfy BackupAPI interface")
-	}
+	_ = api // compile-time interface satisfaction verified by var _ above
 }
 
 func TestUnitBackupAPI_GetBackupByName(t *testing.T) {
@@ -136,7 +136,7 @@ func TestUnitBackupAPI_GetBackupByName(t *testing.T) {
 			}
 
 			r := &backupResource{client: mock}
-			backup, err := r.GetBackupByName(context.Background(), tt.backupName)
+			backup, err := r.GetBackupByName(t.Context(), tt.backupName)
 
 			if tt.expectErr && err == nil {
 				t.Fatal("expected error, got nil")
@@ -199,7 +199,7 @@ func TestUnitBackupAPI_GetPolicyByName(t *testing.T) {
 			}
 
 			r := &backupPolicyResource{client: mock}
-			policy, err := r.GetPolicyByName(context.Background(), tt.policyName)
+			policy, err := r.GetPolicyByName(t.Context(), tt.policyName)
 
 			if tt.expectErr && err == nil {
 				t.Fatal("expected error, got nil")
@@ -225,7 +225,7 @@ func TestUnitBackupAPI_ListError(t *testing.T) {
 	}
 
 	r := &backupResource{client: mock}
-	_, err := r.GetBackupByName(context.Background(), "test")
+	_, err := r.GetBackupByName(t.Context(), "test")
 	if err == nil {
 		t.Fatal("expected error from List failure, got nil")
 	}
@@ -239,7 +239,7 @@ func TestUnitBackupAPI_ListBackupPoliciesError(t *testing.T) {
 	}
 
 	r := &backupPolicyResource{client: mock}
-	_, err := r.GetPolicyByName(context.Background(), "test")
+	_, err := r.GetPolicyByName(t.Context(), "test")
 	if err == nil {
 		t.Fatal("expected error from ListBackupPolicies failure, got nil")
 	}

--- a/internal/services/bucket/bucket_unit_test.go
+++ b/internal/services/bucket/bucket_unit_test.go
@@ -60,9 +60,7 @@ func TestUnitBucketAPI_MockSatisfiesInterface(t *testing.T) {
 	}
 
 	var api BucketAPI = mock
-	if api == nil {
-		t.Fatal("expected mock to satisfy BucketAPI interface")
-	}
+	_ = api // compile-time interface satisfaction verified by var _ above
 }
 
 func TestUnitBucketAPI_GetBucketByName(t *testing.T) {
@@ -106,7 +104,7 @@ func TestUnitBucketAPI_GetBucketByName(t *testing.T) {
 			}
 
 			r := &bucketResource{client: mock}
-			bucket, err := r.GetBucketByName(context.Background(), tt.bucketName)
+			bucket, err := r.GetBucketByName(t.Context(), tt.bucketName)
 
 			if tt.expectErr && err == nil {
 				t.Fatal("expected error, got nil")
@@ -140,7 +138,7 @@ func TestUnitBucketAPI_Delete(t *testing.T) {
 		},
 	}
 
-	err := mock.Delete(context.Background(), "bucket-id-123", "test-reason", "test-note")
+	err := mock.Delete(t.Context(), "bucket-id-123", "test-reason", "test-note")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -160,7 +158,7 @@ func TestUnitBucketAPI_ListError(t *testing.T) {
 	}
 
 	r := &bucketResource{client: mock}
-	_, err := r.GetBucketByName(context.Background(), "any-bucket")
+	_, err := r.GetBucketByName(t.Context(), "any-bucket")
 	if err == nil {
 		t.Fatal("expected error, got nil")
 	}

--- a/internal/services/datacenter/datacenter_unit_test.go
+++ b/internal/services/datacenter/datacenter_unit_test.go
@@ -27,9 +27,7 @@ func TestUnitDataCenterAPI_MockSatisfiesInterface(t *testing.T) {
 	}
 
 	var api DataCenterAPI = mock
-	if api == nil {
-		t.Fatal("expected mock to satisfy DataCenterAPI interface")
-	}
+	_ = api // compile-time interface satisfaction verified by var _ above
 }
 
 func TestUnitDataCenterAPI_ListDatacenters(t *testing.T) {
@@ -64,7 +62,7 @@ func TestUnitDataCenterAPI_ListDatacenters(t *testing.T) {
 				},
 			}
 
-			dcs, err := mock.List(context.Background(), nil)
+			dcs, err := mock.List(t.Context(), nil)
 
 			if tt.expectErr && err == nil {
 				t.Fatal("expected error, got nil")
@@ -88,7 +86,7 @@ func TestUnitDataCenterAPI_ListVerifiesData(t *testing.T) {
 		},
 	}
 
-	dcs, err := mock.List(context.Background(), nil)
+	dcs, err := mock.List(t.Context(), nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/internal/services/domain/domain_unit_test.go
+++ b/internal/services/domain/domain_unit_test.go
@@ -10,16 +10,16 @@ import (
 
 // mockDomainAPI implements DomainAPI for unit testing.
 type mockDomainAPI struct {
-	CreateDomainFn        func(ctx context.Context, createReq *govpsie.CreateDomainRequest) error
-	ListDomainsFn         func(ctx context.Context, options *govpsie.ListOptions) ([]govpsie.Domain, error)
-	DeleteDomainFn        func(ctx context.Context, domainIdentifier, reason, note string) error
-	CreateDnsRecordFn     func(ctx context.Context, createReq govpsie.CreateDnsRecordReq) error
-	UpdateDnsRecordFn     func(ctx context.Context, updateReq *govpsie.UpdateDnsRecordReq) error
-	DeleteDnsRecordFn     func(ctx context.Context, domainIdentifier string, record *govpsie.Record) error
-	AddReverseFn          func(ctx context.Context, reverseReq *govpsie.ReverseRequest) error
+	CreateDomainFn          func(ctx context.Context, createReq *govpsie.CreateDomainRequest) error
+	ListDomainsFn           func(ctx context.Context, options *govpsie.ListOptions) ([]govpsie.Domain, error)
+	DeleteDomainFn          func(ctx context.Context, domainIdentifier, reason, note string) error
+	CreateDnsRecordFn       func(ctx context.Context, createReq govpsie.CreateDnsRecordReq) error
+	UpdateDnsRecordFn       func(ctx context.Context, updateReq *govpsie.UpdateDnsRecordReq) error
+	DeleteDnsRecordFn       func(ctx context.Context, domainIdentifier string, record *govpsie.Record) error
+	AddReverseFn            func(ctx context.Context, reverseReq *govpsie.ReverseRequest) error
 	ListReversePTRRecordsFn func(ctx context.Context) ([]govpsie.ReversePTR, error)
-	UpdateReverseFn       func(ctx context.Context, reverseReq *govpsie.ReverseRequest) error
-	DeleteReverseFn       func(ctx context.Context, ip, vmIdentifier string) error
+	UpdateReverseFn         func(ctx context.Context, reverseReq *govpsie.ReverseRequest) error
+	DeleteReverseFn         func(ctx context.Context, ip, vmIdentifier string) error
 }
 
 func (m *mockDomainAPI) CreateDomain(ctx context.Context, createReq *govpsie.CreateDomainRequest) error {
@@ -67,22 +67,20 @@ var _ DomainAPI = &mockDomainAPI{}
 
 func TestUnitDomainAPI_MockSatisfiesInterface(t *testing.T) {
 	mock := &mockDomainAPI{
-		CreateDomainFn:    func(ctx context.Context, createReq *govpsie.CreateDomainRequest) error { return nil },
-		ListDomainsFn:     func(ctx context.Context, options *govpsie.ListOptions) ([]govpsie.Domain, error) { return nil, nil },
-		DeleteDomainFn:    func(ctx context.Context, domainIdentifier, reason, note string) error { return nil },
-		CreateDnsRecordFn: func(ctx context.Context, createReq govpsie.CreateDnsRecordReq) error { return nil },
-		UpdateDnsRecordFn: func(ctx context.Context, updateReq *govpsie.UpdateDnsRecordReq) error { return nil },
-		DeleteDnsRecordFn: func(ctx context.Context, domainIdentifier string, record *govpsie.Record) error { return nil },
-		AddReverseFn:      func(ctx context.Context, reverseReq *govpsie.ReverseRequest) error { return nil },
+		CreateDomainFn:          func(ctx context.Context, createReq *govpsie.CreateDomainRequest) error { return nil },
+		ListDomainsFn:           func(ctx context.Context, options *govpsie.ListOptions) ([]govpsie.Domain, error) { return nil, nil },
+		DeleteDomainFn:          func(ctx context.Context, domainIdentifier, reason, note string) error { return nil },
+		CreateDnsRecordFn:       func(ctx context.Context, createReq govpsie.CreateDnsRecordReq) error { return nil },
+		UpdateDnsRecordFn:       func(ctx context.Context, updateReq *govpsie.UpdateDnsRecordReq) error { return nil },
+		DeleteDnsRecordFn:       func(ctx context.Context, domainIdentifier string, record *govpsie.Record) error { return nil },
+		AddReverseFn:            func(ctx context.Context, reverseReq *govpsie.ReverseRequest) error { return nil },
 		ListReversePTRRecordsFn: func(ctx context.Context) ([]govpsie.ReversePTR, error) { return nil, nil },
-		UpdateReverseFn:   func(ctx context.Context, reverseReq *govpsie.ReverseRequest) error { return nil },
-		DeleteReverseFn:   func(ctx context.Context, ip, vmIdentifier string) error { return nil },
+		UpdateReverseFn:         func(ctx context.Context, reverseReq *govpsie.ReverseRequest) error { return nil },
+		DeleteReverseFn:         func(ctx context.Context, ip, vmIdentifier string) error { return nil },
 	}
 
 	var api DomainAPI = mock
-	if api == nil {
-		t.Fatal("expected mock to satisfy DomainAPI interface")
-	}
+	_ = api // compile-time interface satisfaction verified by var _ above
 }
 
 func TestUnitDomainAPI_GetDomainByName(t *testing.T) {
@@ -130,7 +128,7 @@ func TestUnitDomainAPI_GetDomainByName(t *testing.T) {
 			}
 
 			r := &domainResource{client: mock}
-			domain, err := r.GetDomainByName(context.Background(), tt.domainName)
+			domain, err := r.GetDomainByName(t.Context(), tt.domainName)
 
 			if tt.expectErr && err == nil {
 				t.Fatal("expected error, got nil")
@@ -156,7 +154,7 @@ func TestUnitDomainAPI_ListDomainsError(t *testing.T) {
 	}
 
 	r := &domainResource{client: mock}
-	_, err := r.GetDomainByName(context.Background(), "test.com")
+	_, err := r.GetDomainByName(t.Context(), "test.com")
 	if err == nil {
 		t.Fatal("expected error from ListDomains failure, got nil")
 	}

--- a/internal/services/fip/fip_unit_test.go
+++ b/internal/services/fip/fip_unit_test.go
@@ -47,9 +47,7 @@ func TestUnitFipAPI_MockSatisfiesInterface(t *testing.T) {
 	}
 
 	var fipAPI FipAPI = fipMock
-	if fipAPI == nil {
-		t.Fatal("expected mock to satisfy FipAPI interface")
-	}
+	_ = fipAPI // compile-time interface satisfaction verified by var _ above
 
 	ipMock := &mockFipIPAPI{
 		ListAllIPsFn:    func(ctx context.Context, options *govpsie.ListOptions) ([]govpsie.IP, error) { return nil, nil },
@@ -57,9 +55,7 @@ func TestUnitFipAPI_MockSatisfiesInterface(t *testing.T) {
 	}
 
 	var ipAPI FipIPAPI = ipMock
-	if ipAPI == nil {
-		t.Fatal("expected mock to satisfy FipIPAPI interface")
-	}
+	_ = ipAPI // compile-time interface satisfaction verified by var _ above
 }
 
 func TestUnitFipAPI_CreateFloatingIP(t *testing.T) {
@@ -88,7 +84,7 @@ func TestUnitFipAPI_CreateFloatingIP(t *testing.T) {
 				},
 			}
 
-			err := mock.CreateFloatingIP(context.Background(), "vm-1", "dc-1", "ipv4")
+			err := mock.CreateFloatingIP(t.Context(), "vm-1", "dc-1", "ipv4")
 			if tt.expectErr && err == nil {
 				t.Fatal("expected error, got nil")
 			}
@@ -101,7 +97,7 @@ func TestUnitFipAPI_CreateFloatingIP(t *testing.T) {
 
 func TestUnitFipAPI_UnassignFloatingIP(t *testing.T) {
 	tests := []struct {
-		name      string
+		name        string
 		unassignErr error
 		expectErr   bool
 	}{
@@ -125,7 +121,7 @@ func TestUnitFipAPI_UnassignFloatingIP(t *testing.T) {
 				},
 			}
 
-			err := mock.UnassignFloatingIP(context.Background(), "ip-1")
+			err := mock.UnassignFloatingIP(t.Context(), "ip-1")
 			if tt.expectErr && err == nil {
 				t.Fatal("expected error, got nil")
 			}
@@ -178,7 +174,7 @@ func TestUnitFipIPAPI_ListAllIPs(t *testing.T) {
 				},
 			}
 
-			ips, err := mock.ListAllIPs(context.Background(), nil)
+			ips, err := mock.ListAllIPs(t.Context(), nil)
 			if tt.expectErr && err == nil {
 				t.Fatal("expected error, got nil")
 			}

--- a/internal/services/firewall/firewall_resource_test.go
+++ b/internal/services/firewall/firewall_resource_test.go
@@ -68,9 +68,7 @@ func TestUnitFirewallAPI_MockSatisfiesInterface(t *testing.T) {
 	}
 
 	var api FirewallAPI = mock
-	if api == nil {
-		t.Fatal("expected mock to satisfy FirewallAPI interface")
-	}
+	_ = api // compile-time interface satisfaction verified by var _ above
 }
 
 func TestUnitFirewallAPI_GetFirewallGroupByName(t *testing.T) {
@@ -116,7 +114,7 @@ func TestUnitFirewallAPI_GetFirewallGroupByName(t *testing.T) {
 			}
 
 			r := &firewallResource{client: mock}
-			fw, err := r.GetFirewallGroupByName(context.Background(), tt.groupName)
+			fw, err := r.GetFirewallGroupByName(t.Context(), tt.groupName)
 
 			if tt.expectErr && err == nil {
 				t.Fatal("expected error, got nil")
@@ -141,7 +139,7 @@ func TestUnitFirewallAPI_Delete(t *testing.T) {
 		},
 	}
 
-	err := mock.Delete(context.Background(), "fw-group-123")
+	err := mock.Delete(t.Context(), "fw-group-123")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -164,7 +162,7 @@ func TestUnitFirewallAPI_AttachToVpsie(t *testing.T) {
 		},
 	}
 
-	err := mock.AttachToVpsie(context.Background(), "group-1", "vm-abc")
+	err := mock.AttachToVpsie(t.Context(), "group-1", "vm-abc")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -190,7 +188,7 @@ func TestUnitFirewallAPI_DetachFromVpsie(t *testing.T) {
 		},
 	}
 
-	err := mock.DetachFromVpsie(context.Background(), "group-1", "vm-abc")
+	err := mock.DetachFromVpsie(t.Context(), "group-1", "vm-abc")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -212,7 +210,7 @@ func TestUnitFirewallAPI_ListErrorPropagation(t *testing.T) {
 	}
 
 	r := &firewallResource{client: mock}
-	_, err := r.GetFirewallGroupByName(context.Background(), "any-group")
+	_, err := r.GetFirewallGroupByName(t.Context(), "any-group")
 
 	if err == nil {
 		t.Fatal("expected error to propagate from List, got nil")
@@ -231,7 +229,7 @@ func TestUnitFirewallAPI_GetErrorPropagation(t *testing.T) {
 		},
 	}
 
-	_, err := mock.Get(context.Background(), "non-existent-id")
+	_, err := mock.Get(t.Context(), "non-existent-id")
 	if err == nil {
 		t.Fatal("expected error to propagate from Get, got nil")
 	}
@@ -249,7 +247,7 @@ func TestUnitFirewallAPI_CreateErrorPropagation(t *testing.T) {
 		},
 	}
 
-	err := mock.Create(context.Background(), "test-group", nil)
+	err := mock.Create(t.Context(), "test-group", nil)
 	if err == nil {
 		t.Fatal("expected error to propagate from Create, got nil")
 	}

--- a/internal/services/gateway/gateway_unit_test.go
+++ b/internal/services/gateway/gateway_unit_test.go
@@ -56,9 +56,7 @@ func TestUnitGatewayAPI_MockSatisfiesInterface(t *testing.T) {
 	}
 
 	var api GatewayAPI = mock
-	if api == nil {
-		t.Fatal("expected mock to satisfy GatewayAPI interface")
-	}
+	_ = api // compile-time interface satisfaction verified by var _ above
 }
 
 func TestUnitGatewayAPI_CreateAndReturnGateway(t *testing.T) {
@@ -116,7 +114,7 @@ func TestUnitGatewayAPI_CreateAndReturnGateway(t *testing.T) {
 			}
 
 			r := &gatewayResource{client: mock}
-			gw, err := r.CreateAndReturnGateway(context.Background(), "ipv4", "dc-1")
+			gw, err := r.CreateAndReturnGateway(t.Context(), "ipv4", "dc-1")
 
 			if tt.expectErr && err == nil {
 				t.Fatal("expected error, got nil")
@@ -142,7 +140,7 @@ func TestUnitGatewayAPI_ListError(t *testing.T) {
 	}
 
 	r := &gatewayResource{client: mock}
-	_, err := r.CreateAndReturnGateway(context.Background(), "ipv4", "dc-1")
+	_, err := r.CreateAndReturnGateway(t.Context(), "ipv4", "dc-1")
 	if err == nil {
 		t.Fatal("expected error from List failure, got nil")
 	}

--- a/internal/services/image/image_unit_test.go
+++ b/internal/services/image/image_unit_test.go
@@ -51,9 +51,7 @@ func TestUnitImageAPI_MockSatisfiesInterface(t *testing.T) {
 	}
 
 	var api ImageAPI = mock
-	if api == nil {
-		t.Fatal("expected mock to satisfy ImageAPI interface")
-	}
+	_ = api // compile-time interface satisfaction verified by var _ above
 }
 
 func TestUnitImageAPI_CheckResourceStatus(t *testing.T) {
@@ -101,7 +99,7 @@ func TestUnitImageAPI_CheckResourceStatus(t *testing.T) {
 			}
 
 			r := &imageResource{client: mock}
-			image, found, err := r.checkResourceStatus(context.Background(), tt.imageLabel)
+			image, found, err := r.checkResourceStatus(t.Context(), tt.imageLabel)
 
 			if tt.expectErr && err == nil {
 				t.Fatal("expected error, got nil")
@@ -132,7 +130,7 @@ func TestUnitImageAPI_DeleteImage(t *testing.T) {
 		},
 	}
 
-	err := mock.DeleteImage(context.Background(), "image-id-123")
+	err := mock.DeleteImage(t.Context(), "image-id-123")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/internal/services/ip/ip_unit_test.go
+++ b/internal/services/ip/ip_unit_test.go
@@ -43,9 +43,7 @@ func TestUnitIPAPI_MockSatisfiesInterface(t *testing.T) {
 	}
 
 	var api IPAPI = mock
-	if api == nil {
-		t.Fatal("expected mock to satisfy IPAPI interface")
-	}
+	_ = api // compile-time interface satisfaction verified by var _ above
 }
 
 func TestUnitIPAPI_ListPublicIPs(t *testing.T) {
@@ -58,7 +56,7 @@ func TestUnitIPAPI_ListPublicIPs(t *testing.T) {
 		},
 	}
 
-	ips, err := mock.ListPublicIPs(context.Background(), nil)
+	ips, err := mock.ListPublicIPs(t.Context(), nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -82,7 +80,7 @@ func TestUnitIPAPI_ListPrivateIPs(t *testing.T) {
 		},
 	}
 
-	ips, err := mock.ListPrivateIPs(context.Background(), nil)
+	ips, err := mock.ListPrivateIPs(t.Context(), nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -104,7 +102,7 @@ func TestUnitIPAPI_ListAllIPs(t *testing.T) {
 		},
 	}
 
-	ips, err := mock.ListAllIPs(context.Background(), nil)
+	ips, err := mock.ListAllIPs(t.Context(), nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/internal/services/kubernetes/kubernetes_resource_test.go
+++ b/internal/services/kubernetes/kubernetes_resource_test.go
@@ -108,9 +108,7 @@ func TestUnitKubernetesAPI_MockSatisfiesInterface(t *testing.T) {
 	}
 
 	var api KubernetesAPI = mock
-	if api == nil {
-		t.Fatal("expected mock to satisfy KubernetesAPI interface")
-	}
+	_ = api // compile-time interface satisfaction verified by var _ above
 }
 
 func TestUnitKubernetesAPI_CheckResourceStatus(t *testing.T) {
@@ -169,7 +167,7 @@ func TestUnitKubernetesAPI_CheckResourceStatus(t *testing.T) {
 			}
 
 			r := &kubernetesResource{client: mock}
-			k8s, found, err := r.checkResourceStatus(context.Background(), tt.clusterName)
+			k8s, found, err := r.checkResourceStatus(t.Context(), tt.clusterName)
 
 			if tt.expectErr && err == nil {
 				t.Fatal("expected error, got nil")
@@ -207,7 +205,7 @@ func TestUnitKubernetesAPI_Get(t *testing.T) {
 		},
 	}
 
-	k8s, err := mock.Get(context.Background(), "test-id-123")
+	k8s, err := mock.Get(t.Context(), "test-id-123")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -235,7 +233,7 @@ func TestUnitKubernetesAPI_Delete(t *testing.T) {
 		},
 	}
 
-	err := mock.Delete(context.Background(), "cluster-id", "terraform", "terraform")
+	err := mock.Delete(t.Context(), "cluster-id", "terraform", "terraform")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -301,7 +299,7 @@ func TestUnitKubernetesAPI_GetGroupByName(t *testing.T) {
 			}
 
 			r := &kubernetesGroupResource{client: mock}
-			group, err := r.GetKubernetesGroupByName(context.Background(), tt.groupName)
+			group, err := r.GetKubernetesGroupByName(t.Context(), tt.groupName)
 
 			if tt.expectErr && err == nil {
 				t.Fatal("expected error, got nil")
@@ -367,7 +365,7 @@ func TestUnitKubernetesAPI_GetGroupByIdentifier(t *testing.T) {
 			}
 
 			r := &kubernetesGroupResource{client: mock}
-			group, err := r.GetKubernetesGroupByIdentifier(context.Background(), tt.identifier)
+			group, err := r.GetKubernetesGroupByIdentifier(t.Context(), tt.identifier)
 
 			if tt.expectErr && err == nil {
 				t.Fatal("expected error, got nil")

--- a/internal/services/loadbalancer/loadbalancer_resource_test.go
+++ b/internal/services/loadbalancer/loadbalancer_resource_test.go
@@ -10,15 +10,15 @@ import (
 
 // mockLoadbalancerAPI implements LoadbalancerAPI for unit testing.
 type mockLoadbalancerAPI struct {
-	ListLBsFn            func(ctx context.Context, options *govpsie.ListOptions) ([]govpsie.LB, error)
-	GetLBFn              func(ctx context.Context, lbID string) (*govpsie.LBDetails, error)
-	CreateLBFn           func(ctx context.Context, createLBReq *govpsie.CreateLBReq) error
-	DeleteLBFn           func(ctx context.Context, lbID, reason, note string) error
-	AddLBRuleFn          func(ctx context.Context, addRuleReq *govpsie.AddRuleReq) error
-	DeleteLBRuleFn       func(ctx context.Context, ruleID string) error
-	UpdateLBDomainFn     func(ctx context.Context, domainUpdateReq *govpsie.DomainUpdateReq) error
+	ListLBsFn             func(ctx context.Context, options *govpsie.ListOptions) ([]govpsie.LB, error)
+	GetLBFn               func(ctx context.Context, lbID string) (*govpsie.LBDetails, error)
+	CreateLBFn            func(ctx context.Context, createLBReq *govpsie.CreateLBReq) error
+	DeleteLBFn            func(ctx context.Context, lbID, reason, note string) error
+	AddLBRuleFn           func(ctx context.Context, addRuleReq *govpsie.AddRuleReq) error
+	DeleteLBRuleFn        func(ctx context.Context, ruleID string) error
+	UpdateLBDomainFn      func(ctx context.Context, domainUpdateReq *govpsie.DomainUpdateReq) error
 	UpdateDomainBackendFn func(ctx context.Context, domainId string, backends []govpsie.Backend) error
-	UpdateLBRulesFn      func(ctx context.Context, ruleUpdateReq *govpsie.RuleUpdateReq) error
+	UpdateLBRulesFn       func(ctx context.Context, ruleUpdateReq *govpsie.RuleUpdateReq) error
 }
 
 func (m *mockLoadbalancerAPI) ListLBs(ctx context.Context, options *govpsie.ListOptions) ([]govpsie.LB, error) {
@@ -92,9 +92,7 @@ func TestUnitLoadbalancerAPI_MockSatisfiesInterface(t *testing.T) {
 	}
 
 	var api LoadbalancerAPI = mock
-	if api == nil {
-		t.Fatal("expected mock to satisfy LoadbalancerAPI interface")
-	}
+	_ = api // compile-time interface satisfaction verified by var _ above
 }
 
 func TestUnitLoadbalancerAPI_CheckResourceStatus(t *testing.T) {
@@ -153,7 +151,7 @@ func TestUnitLoadbalancerAPI_CheckResourceStatus(t *testing.T) {
 			}
 
 			r := &loadbalancerResource{client: mock}
-			lb, found, err := r.checkResourceStatus(context.Background(), tt.lbName)
+			lb, found, err := r.checkResourceStatus(t.Context(), tt.lbName)
 
 			if tt.expectErr && err == nil {
 				t.Fatal("expected error, got nil")
@@ -191,7 +189,7 @@ func TestUnitLoadbalancerAPI_GetLB(t *testing.T) {
 		},
 	}
 
-	lb, err := mock.GetLB(context.Background(), "test-id-123")
+	lb, err := mock.GetLB(t.Context(), "test-id-123")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -222,7 +220,7 @@ func TestUnitLoadbalancerAPI_DeleteLB(t *testing.T) {
 		},
 	}
 
-	err := mock.DeleteLB(context.Background(), "lb-id-1", "terraform provider", "terraform provider")
+	err := mock.DeleteLB(t.Context(), "lb-id-1", "terraform provider", "terraform provider")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -245,7 +243,7 @@ func TestUnitLoadbalancerAPI_ListLBsError(t *testing.T) {
 	}
 
 	r := &loadbalancerResource{client: mock}
-	_, found, err := r.checkResourceStatus(context.Background(), "any-lb")
+	_, found, err := r.checkResourceStatus(t.Context(), "any-lb")
 
 	if err == nil {
 		t.Fatal("expected error, got nil")

--- a/internal/services/monitoring/monitoring_unit_test.go
+++ b/internal/services/monitoring/monitoring_unit_test.go
@@ -10,10 +10,10 @@ import (
 
 // mockMonitoringAPI implements MonitoringAPI for unit testing.
 type mockMonitoringAPI struct {
-	CreateRuleFn                  func(ctx context.Context, createReq *govpsie.CreateMonitoringRuleReq) error
-	ListMonitoringRuleFn          func(ctx context.Context, options *govpsie.ListOptions) ([]govpsie.MonitoringRule, error)
-	ToggleMonitoringRuleStatusFn  func(ctx context.Context, status, ruleIdentifier string) error
-	DeleteMonitoringRuleFn        func(ctx context.Context, ruleIdentifier string) error
+	CreateRuleFn                 func(ctx context.Context, createReq *govpsie.CreateMonitoringRuleReq) error
+	ListMonitoringRuleFn         func(ctx context.Context, options *govpsie.ListOptions) ([]govpsie.MonitoringRule, error)
+	ToggleMonitoringRuleStatusFn func(ctx context.Context, status, ruleIdentifier string) error
+	DeleteMonitoringRuleFn       func(ctx context.Context, ruleIdentifier string) error
 }
 
 func (m *mockMonitoringAPI) CreateRule(ctx context.Context, createReq *govpsie.CreateMonitoringRuleReq) error {
@@ -37,16 +37,16 @@ var _ MonitoringAPI = &mockMonitoringAPI{}
 
 func TestUnitMonitoringAPI_MockSatisfiesInterface(t *testing.T) {
 	mock := &mockMonitoringAPI{
-		CreateRuleFn:                 func(ctx context.Context, createReq *govpsie.CreateMonitoringRuleReq) error { return nil },
-		ListMonitoringRuleFn:         func(ctx context.Context, options *govpsie.ListOptions) ([]govpsie.MonitoringRule, error) { return nil, nil },
+		CreateRuleFn: func(ctx context.Context, createReq *govpsie.CreateMonitoringRuleReq) error { return nil },
+		ListMonitoringRuleFn: func(ctx context.Context, options *govpsie.ListOptions) ([]govpsie.MonitoringRule, error) {
+			return nil, nil
+		},
 		ToggleMonitoringRuleStatusFn: func(ctx context.Context, status, ruleIdentifier string) error { return nil },
 		DeleteMonitoringRuleFn:       func(ctx context.Context, ruleIdentifier string) error { return nil },
 	}
 
 	var api MonitoringAPI = mock
-	if api == nil {
-		t.Fatal("expected mock to satisfy MonitoringAPI interface")
-	}
+	_ = api // compile-time interface satisfaction verified by var _ above
 }
 
 func TestUnitMonitoringAPI_GetRuleByName(t *testing.T) {
@@ -94,7 +94,7 @@ func TestUnitMonitoringAPI_GetRuleByName(t *testing.T) {
 			}
 
 			r := &monitoringRuleResource{client: mock}
-			rule, err := r.GetRuleByName(context.Background(), tt.ruleName)
+			rule, err := r.GetRuleByName(t.Context(), tt.ruleName)
 
 			if tt.expectErr && err == nil {
 				t.Fatal("expected error, got nil")
@@ -120,7 +120,7 @@ func TestUnitMonitoringAPI_ListMonitoringRuleError(t *testing.T) {
 	}
 
 	r := &monitoringRuleResource{client: mock}
-	_, err := r.GetRuleByName(context.Background(), "test")
+	_, err := r.GetRuleByName(t.Context(), "test")
 	if err == nil {
 		t.Fatal("expected error from ListMonitoringRule failure, got nil")
 	}

--- a/internal/services/project/project_unit_test.go
+++ b/internal/services/project/project_unit_test.go
@@ -52,9 +52,7 @@ func TestUnitProjectAPI_MockSatisfiesInterface(t *testing.T) {
 	}
 
 	var api ProjectAPI = mock
-	if api == nil {
-		t.Fatal("expected mock to satisfy ProjectAPI interface")
-	}
+	_ = api // compile-time interface satisfaction verified by var _ above
 }
 
 func TestUnitProjectAPI_GetProjectByName(t *testing.T) {
@@ -106,7 +104,7 @@ func TestUnitProjectAPI_GetProjectByName(t *testing.T) {
 			}
 
 			r := &projectResource{client: mock}
-			project, err := r.GetProjectByName(context.Background(), tt.projectName)
+			project, err := r.GetProjectByName(t.Context(), tt.projectName)
 
 			if tt.expectErr && err == nil {
 				t.Fatal("expected error, got nil")
@@ -134,7 +132,7 @@ func TestUnitProjectAPI_Delete(t *testing.T) {
 		},
 	}
 
-	err := mock.Delete(context.Background(), "project-id-123")
+	err := mock.Delete(t.Context(), "project-id-123")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/internal/services/script/script_unit_test.go
+++ b/internal/services/script/script_unit_test.go
@@ -60,9 +60,7 @@ func TestUnitScriptAPI_MockSatisfiesInterface(t *testing.T) {
 	}
 
 	var api ScriptAPI = mock
-	if api == nil {
-		t.Fatal("expected mock to satisfy ScriptAPI interface")
-	}
+	_ = api // compile-time interface satisfaction verified by var _ above
 }
 
 func TestUnitScriptAPI_GetScriptByName(t *testing.T) {
@@ -114,7 +112,7 @@ func TestUnitScriptAPI_GetScriptByName(t *testing.T) {
 			}
 
 			r := &scriptResource{client: mock}
-			script, err := r.GetScriptByName(context.Background(), tt.scriptName)
+			script, err := r.GetScriptByName(t.Context(), tt.scriptName)
 
 			if tt.expectErr && err == nil {
 				t.Fatal("expected error, got nil")
@@ -139,7 +137,7 @@ func TestUnitScriptAPI_DeleteScript(t *testing.T) {
 		},
 	}
 
-	err := mock.DeleteScript(context.Background(), "script-id-123")
+	err := mock.DeleteScript(t.Context(), "script-id-123")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/internal/services/server/server_resource_test.go
+++ b/internal/services/server/server_resource_test.go
@@ -9,18 +9,18 @@ import (
 
 // mockServerAPI implements ServerAPI for unit testing.
 type mockServerAPI struct {
-	CreateServerFn           func(ctx context.Context, req *govpsie.CreateServerRequest) error
-	ListFn                   func(ctx context.Context, options *govpsie.ListOptions) ([]govpsie.VmData, error)
-	GetServerByIdentifierFn  func(ctx context.Context, identifierId string) (*govpsie.VmData, error)
-	DeleteServerFn           func(ctx context.Context, identifierId, password, reason, note string) error
-	ChangeHostNameFn         func(ctx context.Context, identifierId string, newHostname string) error
-	StartServerFn            func(ctx context.Context, identifierId string) error
-	StopServerFn             func(ctx context.Context, identifierId string) error
-	LockFn                   func(ctx context.Context, identifierId string) error
-	UnLockFn                 func(ctx context.Context, identifierId string) error
-	AddSshFn                 func(ctx context.Context, identifierId, sshKeyIdentifier string) error
-	AddScriptFn              func(ctx context.Context, identifierId, scriptIdentifier string) error
-	ResizeServerFn           func(ctx context.Context, identifierId, cpu, ram string) error
+	CreateServerFn          func(ctx context.Context, req *govpsie.CreateServerRequest) error
+	ListFn                  func(ctx context.Context, options *govpsie.ListOptions) ([]govpsie.VmData, error)
+	GetServerByIdentifierFn func(ctx context.Context, identifierId string) (*govpsie.VmData, error)
+	DeleteServerFn          func(ctx context.Context, identifierId, password, reason, note string) error
+	ChangeHostNameFn        func(ctx context.Context, identifierId string, newHostname string) error
+	StartServerFn           func(ctx context.Context, identifierId string) error
+	StopServerFn            func(ctx context.Context, identifierId string) error
+	LockFn                  func(ctx context.Context, identifierId string) error
+	UnLockFn                func(ctx context.Context, identifierId string) error
+	AddSshFn                func(ctx context.Context, identifierId, sshKeyIdentifier string) error
+	AddScriptFn             func(ctx context.Context, identifierId, scriptIdentifier string) error
+	ResizeServerFn          func(ctx context.Context, identifierId, cpu, ram string) error
 }
 
 func (m *mockServerAPI) CreateServer(ctx context.Context, req *govpsie.CreateServerRequest) error {
@@ -115,18 +115,16 @@ func TestUnitServerAPI_MockSatisfiesInterface(t *testing.T) {
 	}
 
 	var api ServerAPI = mock
-	if api == nil {
-		t.Fatal("expected mock to satisfy ServerAPI interface")
-	}
+	_ = api // compile-time interface satisfaction verified by var _ above
 }
 
 func TestUnitServerAPI_CheckResourceStatus(t *testing.T) {
 	tests := []struct {
-		name          string
-		hostname      string
-		servers       []govpsie.VmData
-		expectFound   bool
-		expectErr     bool
+		name        string
+		hostname    string
+		servers     []govpsie.VmData
+		expectFound bool
+		expectErr   bool
 	}{
 		{
 			name:     "server found by hostname",
@@ -165,7 +163,7 @@ func TestUnitServerAPI_CheckResourceStatus(t *testing.T) {
 			}
 
 			r := &serverResource{client: mock}
-			server, found, err := r.checkResourceStatus(context.Background(), tt.hostname)
+			server, found, err := r.checkResourceStatus(t.Context(), tt.hostname)
 
 			if tt.expectErr && err == nil {
 				t.Fatal("expected error, got nil")
@@ -203,7 +201,7 @@ func TestUnitServerAPI_GetServerByIdentifier(t *testing.T) {
 		},
 	}
 
-	server, err := mock.GetServerByIdentifier(context.Background(), "test-id-123")
+	server, err := mock.GetServerByIdentifier(t.Context(), "test-id-123")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -233,7 +231,7 @@ func TestUnitServerAPI_DeleteServer(t *testing.T) {
 		},
 	}
 
-	err := mock.DeleteServer(context.Background(), "server-id", "pass123", "testing", "test note")
+	err := mock.DeleteServer(t.Context(), "server-id", "pass123", "testing", "test note")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/internal/services/snapshot/snapshot_unit_test.go
+++ b/internal/services/snapshot/snapshot_unit_test.go
@@ -10,17 +10,17 @@ import (
 
 // mockSnapshotAPI implements SnapshotAPI for unit testing.
 type mockSnapshotAPI struct {
-	CreateFn                func(ctx context.Context, name, vmIdentifier, note string) error
-	ListFn                  func(ctx context.Context, options *govpsie.ListOptions) ([]govpsie.Snapshot, error)
-	GetFn                   func(ctx context.Context, buckupIdentifier string) (*govpsie.Snapshot, error)
-	UpdateFn                func(ctx context.Context, snapshotIdentifier, newNote string) error
-	DeleteFn                func(ctx context.Context, snapshotIdentifier, reason, note string) error
-	CreateSnapShotPolicyFn  func(ctx context.Context, createReq *govpsie.CreateSnapShotPolicyReq) error
-	GetSnapShotPolicyFn     func(ctx context.Context, identifier string) (*govpsie.SnapShotPolicy, error)
-	ListSnapShotPoliciesFn  func(ctx context.Context, options *govpsie.ListOptions) ([]govpsie.SnapShotPolicyListDetail, error)
-	AttachSnapShotPolicyFn  func(ctx context.Context, policyId string, vms []string) error
-	DetachSnapShotPolicyFn  func(ctx context.Context, policyId string, vms []string) error
-	DeleteSnapShotPolicyFn  func(ctx context.Context, policyId, identifier string) error
+	CreateFn               func(ctx context.Context, name, vmIdentifier, note string) error
+	ListFn                 func(ctx context.Context, options *govpsie.ListOptions) ([]govpsie.Snapshot, error)
+	GetFn                  func(ctx context.Context, buckupIdentifier string) (*govpsie.Snapshot, error)
+	UpdateFn               func(ctx context.Context, snapshotIdentifier, newNote string) error
+	DeleteFn               func(ctx context.Context, snapshotIdentifier, reason, note string) error
+	CreateSnapShotPolicyFn func(ctx context.Context, createReq *govpsie.CreateSnapShotPolicyReq) error
+	GetSnapShotPolicyFn    func(ctx context.Context, identifier string) (*govpsie.SnapShotPolicy, error)
+	ListSnapShotPoliciesFn func(ctx context.Context, options *govpsie.ListOptions) ([]govpsie.SnapShotPolicyListDetail, error)
+	AttachSnapShotPolicyFn func(ctx context.Context, policyId string, vms []string) error
+	DetachSnapShotPolicyFn func(ctx context.Context, policyId string, vms []string) error
+	DeleteSnapShotPolicyFn func(ctx context.Context, policyId, identifier string) error
 }
 
 func (m *mockSnapshotAPI) Create(ctx context.Context, name, vmIdentifier, note string) error {
@@ -79,16 +79,16 @@ func TestUnitSnapshotAPI_MockSatisfiesInterface(t *testing.T) {
 		DeleteFn:               func(ctx context.Context, snapshotIdentifier, reason, note string) error { return nil },
 		CreateSnapShotPolicyFn: func(ctx context.Context, createReq *govpsie.CreateSnapShotPolicyReq) error { return nil },
 		GetSnapShotPolicyFn:    func(ctx context.Context, identifier string) (*govpsie.SnapShotPolicy, error) { return nil, nil },
-		ListSnapShotPoliciesFn: func(ctx context.Context, options *govpsie.ListOptions) ([]govpsie.SnapShotPolicyListDetail, error) { return nil, nil },
+		ListSnapShotPoliciesFn: func(ctx context.Context, options *govpsie.ListOptions) ([]govpsie.SnapShotPolicyListDetail, error) {
+			return nil, nil
+		},
 		AttachSnapShotPolicyFn: func(ctx context.Context, policyId string, vms []string) error { return nil },
 		DetachSnapShotPolicyFn: func(ctx context.Context, policyId string, vms []string) error { return nil },
 		DeleteSnapShotPolicyFn: func(ctx context.Context, policyId, identifier string) error { return nil },
 	}
 
 	var api SnapshotAPI = mock
-	if api == nil {
-		t.Fatal("expected mock to satisfy SnapshotAPI interface")
-	}
+	_ = api // compile-time interface satisfaction verified by var _ above
 }
 
 func TestUnitSnapshotAPI_GetSnapshotByName(t *testing.T) {
@@ -136,7 +136,7 @@ func TestUnitSnapshotAPI_GetSnapshotByName(t *testing.T) {
 			}
 
 			r := &serverSnapshotResource{client: mock}
-			snap, err := r.GetSnapshotByName(context.Background(), tt.snapshotName)
+			snap, err := r.GetSnapshotByName(t.Context(), tt.snapshotName)
 
 			if tt.expectErr && err == nil {
 				t.Fatal("expected error, got nil")
@@ -199,7 +199,7 @@ func TestUnitSnapshotAPI_GetPolicyByName(t *testing.T) {
 			}
 
 			r := &snapshotPolicyResource{client: mock}
-			policy, err := r.GetPolicyByName(context.Background(), tt.policyName)
+			policy, err := r.GetPolicyByName(t.Context(), tt.policyName)
 
 			if tt.expectErr && err == nil {
 				t.Fatal("expected error, got nil")
@@ -225,7 +225,7 @@ func TestUnitSnapshotAPI_ListError(t *testing.T) {
 	}
 
 	r := &serverSnapshotResource{client: mock}
-	_, err := r.GetSnapshotByName(context.Background(), "test")
+	_, err := r.GetSnapshotByName(t.Context(), "test")
 	if err == nil {
 		t.Fatal("expected error from List failure, got nil")
 	}
@@ -239,7 +239,7 @@ func TestUnitSnapshotAPI_ListSnapShotPoliciesError(t *testing.T) {
 	}
 
 	r := &snapshotPolicyResource{client: mock}
-	_, err := r.GetPolicyByName(context.Background(), "test")
+	_, err := r.GetPolicyByName(t.Context(), "test")
 	if err == nil {
 		t.Fatal("expected error from ListSnapShotPolicies failure, got nil")
 	}

--- a/internal/services/sshkey/sshkey_unit_test.go
+++ b/internal/services/sshkey/sshkey_unit_test.go
@@ -52,9 +52,7 @@ func TestUnitSshkeyAPI_MockSatisfiesInterface(t *testing.T) {
 	}
 
 	var api SshkeyAPI = mock
-	if api == nil {
-		t.Fatal("expected mock to satisfy SshkeyAPI interface")
-	}
+	_ = api // compile-time interface satisfaction verified by var _ above
 }
 
 func TestUnitSshkeyAPI_GetSshkeyByName(t *testing.T) {
@@ -102,7 +100,7 @@ func TestUnitSshkeyAPI_GetSshkeyByName(t *testing.T) {
 			}
 
 			r := &sshkeyResource{client: mock}
-			key, err := r.GetSshkeyByName(context.Background(), tt.sshkeyName)
+			key, err := r.GetSshkeyByName(t.Context(), tt.sshkeyName)
 
 			if tt.expectErr && err == nil {
 				t.Fatal("expected error, got nil")
@@ -128,7 +126,7 @@ func TestUnitSshkeyAPI_ListError(t *testing.T) {
 	}
 
 	r := &sshkeyResource{client: mock}
-	_, err := r.GetSshkeyByName(context.Background(), "test")
+	_, err := r.GetSshkeyByName(t.Context(), "test")
 	if err == nil {
 		t.Fatal("expected error from List failure, got nil")
 	}
@@ -160,7 +158,7 @@ func TestUnitSshkeyAPI_CreateAndGet(t *testing.T) {
 		},
 	}
 
-	err := mock.Create(context.Background(), "ssh-ed25519 AAAA...", "my-key")
+	err := mock.Create(t.Context(), "ssh-ed25519 AAAA...", "my-key")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -174,7 +172,7 @@ func TestUnitSshkeyAPI_CreateAndGet(t *testing.T) {
 		t.Fatalf("expected name 'my-key', got %q", createName)
 	}
 
-	key, err := mock.Get(context.Background(), "my-key")
+	key, err := mock.Get(t.Context(), "my-key")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/internal/services/storage/storage_unit_test.go
+++ b/internal/services/storage/storage_unit_test.go
@@ -60,9 +60,7 @@ func TestUnitStorageAPI_MockSatisfiesInterface(t *testing.T) {
 	}
 
 	var api StorageAPI = mock
-	if api == nil {
-		t.Fatal("expected mock to satisfy StorageAPI interface")
-	}
+	_ = api // compile-time interface satisfaction verified by var _ above
 }
 
 func TestUnitStorageAPI_GetVolumeByName(t *testing.T) {
@@ -110,7 +108,7 @@ func TestUnitStorageAPI_GetVolumeByName(t *testing.T) {
 			}
 
 			r := &storageResource{client: mock}
-			vol, err := r.GetVolumeByName(context.Background(), tt.volumeName)
+			vol, err := r.GetVolumeByName(t.Context(), tt.volumeName)
 
 			if tt.expectErr && err == nil {
 				t.Fatal("expected error, got nil")
@@ -166,7 +164,7 @@ func TestUnitStorageAPI_GetVolumeByIdentifier(t *testing.T) {
 			}
 
 			r := &storageResource{client: mock}
-			vol, err := r.GetVolumeByIdentifier(context.Background(), tt.identifier)
+			vol, err := r.GetVolumeByIdentifier(t.Context(), tt.identifier)
 
 			if tt.expectErr && err == nil {
 				t.Fatal("expected error, got nil")
@@ -192,12 +190,12 @@ func TestUnitStorageAPI_ListAllError(t *testing.T) {
 	}
 
 	r := &storageResource{client: mock}
-	_, err := r.GetVolumeByName(context.Background(), "test")
+	_, err := r.GetVolumeByName(t.Context(), "test")
 	if err == nil {
 		t.Fatal("expected error from ListAll failure, got nil")
 	}
 
-	_, err = r.GetVolumeByIdentifier(context.Background(), "test-id")
+	_, err = r.GetVolumeByIdentifier(t.Context(), "test-id")
 	if err == nil {
 		t.Fatal("expected error from ListAll failure, got nil")
 	}

--- a/internal/services/vpc/vpc_unit_test.go
+++ b/internal/services/vpc/vpc_unit_test.go
@@ -10,11 +10,11 @@ import (
 
 // mockVpcAPI implements VpcAPI for unit testing.
 type mockVpcAPI struct {
-	CreateVpcFn      func(ctx context.Context, createReq *govpsie.CreateVpcReq) error
-	ListFn           func(ctx context.Context, options *govpsie.ListOptions) ([]govpsie.VPC, error)
-	GetFn            func(ctx context.Context, id string) (*govpsie.VPC, error)
-	DeleteVpcFn      func(ctx context.Context, vpcId, reason, note string) error
-	AssignServerFn   func(ctx context.Context, assignReq *govpsie.AssignServerReq) error
+	CreateVpcFn        func(ctx context.Context, createReq *govpsie.CreateVpcReq) error
+	ListFn             func(ctx context.Context, options *govpsie.ListOptions) ([]govpsie.VPC, error)
+	GetFn              func(ctx context.Context, id string) (*govpsie.VPC, error)
+	DeleteVpcFn        func(ctx context.Context, vpcId, reason, note string) error
+	AssignServerFn     func(ctx context.Context, assignReq *govpsie.AssignServerReq) error
 	ReleasePrivateIPFn func(ctx context.Context, vmIdentifer string, privateIpId int) error
 }
 
@@ -57,18 +57,16 @@ var _ IPLookupAPI = &mockIPLookupAPI{}
 
 func TestUnitVpcAPI_MockSatisfiesInterface(t *testing.T) {
 	mock := &mockVpcAPI{
-		CreateVpcFn:      func(ctx context.Context, createReq *govpsie.CreateVpcReq) error { return nil },
-		ListFn:           func(ctx context.Context, options *govpsie.ListOptions) ([]govpsie.VPC, error) { return nil, nil },
-		GetFn:            func(ctx context.Context, id string) (*govpsie.VPC, error) { return nil, nil },
-		DeleteVpcFn:      func(ctx context.Context, vpcId, reason, note string) error { return nil },
-		AssignServerFn:   func(ctx context.Context, assignReq *govpsie.AssignServerReq) error { return nil },
+		CreateVpcFn:        func(ctx context.Context, createReq *govpsie.CreateVpcReq) error { return nil },
+		ListFn:             func(ctx context.Context, options *govpsie.ListOptions) ([]govpsie.VPC, error) { return nil, nil },
+		GetFn:              func(ctx context.Context, id string) (*govpsie.VPC, error) { return nil, nil },
+		DeleteVpcFn:        func(ctx context.Context, vpcId, reason, note string) error { return nil },
+		AssignServerFn:     func(ctx context.Context, assignReq *govpsie.AssignServerReq) error { return nil },
 		ReleasePrivateIPFn: func(ctx context.Context, vmIdentifer string, privateIpId int) error { return nil },
 	}
 
 	var api VpcAPI = mock
-	if api == nil {
-		t.Fatal("expected mock to satisfy VpcAPI interface")
-	}
+	_ = api // compile-time interface satisfaction verified by var _ above
 }
 
 func TestUnitVpcAPI_GetVpcByName(t *testing.T) {
@@ -116,7 +114,7 @@ func TestUnitVpcAPI_GetVpcByName(t *testing.T) {
 			}
 
 			r := &vpcResource{client: mock}
-			vpc, err := r.GetVpcByName(context.Background(), tt.vpcName)
+			vpc, err := r.GetVpcByName(t.Context(), tt.vpcName)
 
 			if tt.expectErr && err == nil {
 				t.Fatal("expected error, got nil")
@@ -142,7 +140,7 @@ func TestUnitVpcAPI_ListError(t *testing.T) {
 	}
 
 	r := &vpcResource{client: mock}
-	_, err := r.GetVpcByName(context.Background(), "test")
+	_, err := r.GetVpcByName(t.Context(), "test")
 	if err == nil {
 		t.Fatal("expected error from List failure, got nil")
 	}

--- a/tests/e2e_test.go
+++ b/tests/e2e_test.go
@@ -158,6 +158,15 @@ func TestE2EProductionReadinessFullCycle(t *testing.T) {
 // E2E Test Config Helpers
 // ---------------------------------------------------------------------------
 
+// Blank identifier references ensure these config helpers are not flagged as
+// unused while the E2E test steps remain placeholder TODOs. Remove these once
+// the test steps call the helpers directly.
+var (
+	_ = testE2EProductionReadinessConfig_phase1
+	_ = testE2EProductionReadinessConfig_phase3
+	_ = testE2EProductionReadinessConfig_invalidEmpty
+)
+
 // testE2EProductionReadinessConfig_phase1 returns a multi-resource config
 // that exercises sensitive field masking and schema descriptions.
 func testE2EProductionReadinessConfig_phase1() string {

--- a/tests/integration_test.go
+++ b/tests/integration_test.go
@@ -259,6 +259,14 @@ func TestAccImportStateCompositeID_InvalidFormat(t *testing.T) {
 // Test Config Helpers
 // ---------------------------------------------------------------------------
 
+// Blank identifier references ensure these helpers are not flagged as unused
+// while the acceptance test steps remain placeholder TODOs. Remove these once
+// the test steps call the helpers directly.
+var (
+	_ = testAccDnsRecordConfig
+	_ = testAccImportStateIDFunc
+)
+
 // testAccSensitiveFieldConfig returns a Terraform config for testing sensitive
 // field masking. Includes an sshkey resource with a private_key.
 func testAccSensitiveFieldConfig() string {
@@ -291,10 +299,6 @@ data "vpsie_firewalls" "test" {}
 // testAccDnsRecordConfig returns a Terraform config for a DNS record resource
 // that can be used to test composite ID import.
 func testAccDnsRecordConfig(domainName, recordType, recordName, value string) string {
-	// TODO: Return HCL config string with:
-	// - vpsie_project resource (required by domain)
-	// - vpsie_domain resource with domain_name
-	// - vpsie_dns_record resource with domain_identifier, type, name, value
 	return fmt.Sprintf(`
 resource "vpsie_project" "test" {
   name        = "tf-acc-import-test-project"
@@ -306,8 +310,9 @@ resource "vpsie_domain" "test" {
   project_identifier = vpsie_project.test.identifier
 }
 
-# TODO: Complete dns_record config once resource schema is confirmed
-`, domainName)
+# TODO: Complete dns_record resource block once resource schema is confirmed
+# Placeholder values: type=%q name=%q value=%q
+`, domainName, recordType, recordName, value)
 }
 
 // testAccImportStateIDFunc constructs a composite import ID from resource


### PR DESCRIPTION
## Summary

Fixes golangci-lint failures from CI on PR #29:

- **SA4023**: Replace always-false nil checks on interface variables holding concrete pointers with blank identifier assignments (21 test files)
- **usetesting**: Replace `context.Background()` with `t.Context()` in all unit test functions per Go 1.24 convention (21 test files)
- **unused**: Add blank identifier references for test skeleton helpers not yet called

## Test plan
- [x] `golangci-lint run ./...` — zero errors
- [x] `go build -v .` — passes
- [x] `go test ./... -count=1` — all tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)