### PR TITLE
ci: split test job into unit-tests and acceptance-tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -54,9 +54,25 @@ jobs:
           git diff --compact-summary --exit-code || \
             (echo; echo "Unexpected difference in directories after code generation. Run 'go generate ./...' command and commit."; exit 1)
 
+  # Run unit tests (acceptance tests auto-skip when TF_ACC is unset)
+  unit-tests:
+    name: Unit Tests
+    needs: build
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+      - uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
+        with:
+          go-version-file: 'go.mod'
+          cache: true
+      - run: go mod download
+      - run: go test -v -cover ./...
+        timeout-minutes: 5
+
   # Run acceptance tests in a matrix with Terraform CLI versions
-  test:
-    name: Terraform Provider Acceptance Tests
+  acceptance-tests:
+    name: Acceptance Tests (Terraform ${{ matrix.terraform }})
     needs: build
     runs-on: ubuntu-latest
     continue-on-error: true
@@ -64,7 +80,6 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # list whatever Terraform versions here you would like to support
         terraform:
           - '1.0.*'
           - '1.1.*'


### PR DESCRIPTION
## Summary
- Split the single `test` job into `unit-tests` (required) and `acceptance-tests` (optional)
- Unit tests run without `TF_ACC`, so acceptance tests auto-skip via `resource.Test()` — CI stays green regardless of token validity
- Acceptance tests keep `continue-on-error: true` and the Terraform version matrix, so failures don't block PRs

## Test plan
- [ ] Verify `unit-tests` job passes (TestAcc* tests show SKIP)
- [ ] Verify `acceptance-tests` job still runs (expected to fail with expired token)
- [ ] Verify PR is mergeable when unit-tests pass but acceptance-tests fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)